### PR TITLE
Add `mintlist_create` + `mintlist_add_mint_infos` instructions

### DIFF
--- a/@types/buffer-layout.d.ts
+++ b/@types/buffer-layout.d.ts
@@ -1,0 +1,90 @@
+import { Buffer } from "buffer";
+
+declare module "buffer-layout" {
+  // TODO: remove `any`.
+
+  export class Layout<T = any> {
+    span: number;
+    property?: string;
+
+    constructor(span: number, property?: string);
+
+    decode(b: Buffer | string, offset?: number): T;
+    encode(src: T, b: Buffer, offset?: number): number;
+    getSpan(b: Buffer, offset?: number): number;
+    replicate(name: string): this;
+  }
+  // TODO: remove any.
+  export class Structure<T = any> extends Layout<T> {
+    span: any;
+  }
+  export function greedy(
+    elementSpan?: number,
+    property?: string
+  ): Layout<number>;
+  export function offset<T>(
+    layout: Layout<T>,
+    offset?: number,
+    property?: string
+  ): Layout<T>;
+  export function u8(property?: string): Layout<number>;
+  export function u16(property?: string): Layout<number>;
+  export function u24(property?: string): Layout<number>;
+  export function u32(property?: string): Layout<number>;
+  export function u40(property?: string): Layout<number>;
+  export function u48(property?: string): Layout<number>;
+  export function nu64(property?: string): Layout<number>;
+  export function u16be(property?: string): Layout<number>;
+  export function u24be(property?: string): Layout<number>;
+  export function u32be(property?: string): Layout<number>;
+  export function u40be(property?: string): Layout<number>;
+  export function u48be(property?: string): Layout<number>;
+  export function nu64be(property?: string): Layout<number>;
+  export function s8(property?: string): Layout<number>;
+  export function s16(property?: string): Layout<number>;
+  export function s24(property?: string): Layout<number>;
+  export function s32(property?: string): Layout<number>;
+  export function s40(property?: string): Layout<number>;
+  export function s48(property?: string): Layout<number>;
+  export function ns64(property?: string): Layout<number>;
+  export function s16be(property?: string): Layout<number>;
+  export function s24be(property?: string): Layout<number>;
+  export function s32be(property?: string): Layout<number>;
+  export function s40be(property?: string): Layout<number>;
+  export function s48be(property?: string): Layout<number>;
+  export function ns64be(property?: string): Layout<number>;
+  export function f32(property?: string): Layout<number>;
+  export function f32be(property?: string): Layout<number>;
+  export function f64(property?: string): Layout<number>;
+  export function f64be(property?: string): Layout<number>;
+  export function struct<T>(
+    fields: Layout<any>[],
+    property?: string,
+    decodePrefixes?: boolean
+  ): Layout<T>;
+  export function bits(
+    word: Layout<number>,
+    msb?: boolean,
+    property?: string
+  ): any;
+  export function seq<T>(
+    elementLayout: Layout<T>,
+    count: number | Layout<number>,
+    property?: string
+  ): Layout<T[]>;
+  export function union(
+    discr: Layout<any>,
+    defaultLayout?: any,
+    property?: string
+  ): any;
+  export function unionLayoutDiscriminator(
+    layout: Layout<any>,
+    property?: string
+  ): any;
+  export function blob(
+    length: number | Layout<number>,
+    property?: string
+  ): Layout<Buffer>;
+  export function cstr(property?: string): Layout<string>;
+  export function utf8(maxSpan: number, property?: string): Layout<string>;
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@project-serum/anchor": "^0.24.2",
+    "@project-serum/borsh": "^0.2.5",
     "@project-serum/serum": "^0.13.64",
     "@solana/web3.js": "^1.39.1",
     "@types/jest": "^27.4.1",
@@ -26,6 +27,8 @@
     "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",
     "buffer": "^6.0.3",
+    "buffer-layout": "^1.2.2",
+    "camelcase": "^6.3.0",
     "jest": "^27.5.1",
     "lodash": "^4.17.21",
     "luxon": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@project-serum/anchor': ^0.24.2
+  '@project-serum/borsh': ^0.2.5
   '@project-serum/serum': ^0.13.64
   '@solana/web3.js': ^1.39.1
   '@types/jest': ^27.4.1
@@ -9,6 +10,8 @@ specifiers:
   axios: ^0.26.1
   bignumber.js: ^9.0.2
   buffer: ^6.0.3
+  buffer-layout: ^1.2.2
+  camelcase: ^6.3.0
   jest: ^27.5.1
   lodash: ^4.17.21
   luxon: ^2.3.2
@@ -20,6 +23,7 @@ specifiers:
 
 dependencies:
   '@project-serum/anchor': 0.24.2
+  '@project-serum/borsh': 0.2.5_@solana+web3.js@1.39.1
   '@project-serum/serum': 0.13.64
   '@solana/web3.js': 1.39.1
   '@types/jest': 27.4.1
@@ -27,6 +31,8 @@ dependencies:
   axios: 0.26.1
   bignumber.js: 9.0.2
   buffer: 6.0.3
+  buffer-layout: 1.2.2
+  camelcase: 6.3.0
   jest: 27.5.1
   lodash: 4.17.21
   luxon: 2.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@project-serum/anchor': ^0.24.2
@@ -32,7 +32,7 @@ dependencies:
   luxon: 2.3.2
   p-limit: 4.0.0
   prettier: 2.6.2
-  ts-jest: 27.1.4_9985e1834e803358b7be1e6ce5ca0eea
+  ts-jest: 27.1.4_tgc6da2oqazvrn56dzwolsqo5i
   typescript: 4.6.3
   zod: 3.14.4
 
@@ -3018,7 +3018,7 @@ packages:
       circular-json: 0.5.9
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 7.5.7_d6955b83f926115bf12ffeabab6deaae
+      ws: 7.5.7_22kvxa7zeyivx4jp72v2w3pkvy
     optionalDependencies:
       bufferutil: 4.0.6
       utf-8-validate: 5.0.9
@@ -3307,7 +3307,7 @@ packages:
     resolution: {integrity: sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=}
     dev: false
 
-  /ts-jest/27.1.4_9985e1834e803358b7be1e6ce5ca0eea:
+  /ts-jest/27.1.4_tgc6da2oqazvrn56dzwolsqo5i:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -3555,7 +3555,7 @@ packages:
         optional: true
     dev: false
 
-  /ws/7.5.7_d6955b83f926115bf12ffeabab6deaae:
+  /ws/7.5.7_22kvxa7zeyivx4jp72v2w3pkvy:
     resolution: {integrity: sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==}
     engines: {node: '>=8.3.0'}
     peerDependencies:

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -38,7 +38,17 @@ pub struct NftAccount {
 #[account(zero_copy)]
 pub struct MintlistAccount {
     pub version: u8, // 1
-    _version_alignment: [u8; 7], // 7
+
+    /// Order of going through the list of `MintInfo`'s during the minting process.
+    pub minting_order: MintingOrder, // 1
+
+    /// Maximum number of NFTs that can be minted from the mintlist.
+    pub num_mints: u16, // 2
+
+    /// Number of NFTs already minted from the mintlist.
+    pub mints_redeemed: u16, // 2
+
+    _alignment: [u8; 2], // 2
 
     /// The pubkey that will be set as the creator of the NTFs minted from the mintlist.
     pub creator: Pubkey, // 32
@@ -52,16 +62,6 @@ pub struct MintlistAccount {
     /// Price to pay for minting an NFT from the mintlist.
     pub price: u64, // 8
 
-    /// Maximum number of NFTs that can be minted from the mintlist.
-    pub num_mints: u64, // 8
-
-    /// Number of NFTs already minted from the mintlist.
-    pub mints_redeemed: u64, // 8
-
-    /// Order of going through the list of `MintInfo`'s during the minting process.
-    pub minting_order: MintingOrder, // 1
-    _minting_order_alignment: [u8; 7], // 7
-
     /// Optional pubkey of the collection the NFTs minted from the mintlist will belong to.
     pub collection: Pubkey, // 32
 
@@ -73,11 +73,19 @@ pub struct MintlistAccount {
 }
 
 impl MintlistAccount {
-    pub fn size(num_mints: u64) -> usize {
+    pub fn size(num_mints: u16) -> usize {
         // Account discriminator
         8
         // version
-        + 8
+        + 1
+        // minting_order
+        + 1
+        // num_mints
+        + 2
+        // mints_redeemed
+        + 2
+        // _alignment
+        + 2
         // creator
         + 32
         // treasury_sol
@@ -85,12 +93,6 @@ impl MintlistAccount {
         // go_live_date
         + 8
         // price
-        + 8
-        // num_mints
-        + 8
-        // mints_redeemed
-        + 8
-        // minting_order
         + 8
         // collection
         + 32
@@ -126,6 +128,7 @@ pub struct MintInfo {
     pub image_url: [u8; 64], // 64
     pub metadata_url: [u8; 64], // 64
     pub minted: bool, // 1
+    _alignment: [u8; 7] // 7
 }
 
 impl MintInfo {
@@ -138,6 +141,8 @@ impl MintInfo {
         + 64
         // minted
         + 1
+        // _alignment
+        + 7
     }
 }
 

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -1,4 +1,6 @@
+use std::convert::TryFrom;
 use anchor_lang::prelude::*;
+use crate::errors::NftokenError;
 
 #[account]
 pub struct CollectionAccount {
@@ -32,4 +34,109 @@ pub struct NftAccount {
 
     pub created_at: i64, // 8
 }
+
+#[account]
+pub struct MintlistAccount {
+    pub version: u8, // 1
+
+    /// The pubkey that will be set as the creator of the NTFs minted from the mintlist.
+    pub creator: Pubkey, // 32
+
+    /// SOL wallet to receive proceedings from SOL payments.
+    pub treasury_sol: Pubkey, // 32
+
+    /// Timestamp when minting is allowed.
+    pub go_live_date: i64, // 8
+
+    /// Price to pay for minting an NFT from the mintlist.
+    pub price: u64, // 8
+
+    /// Maximum number of NFTs that can be minted from the mintlist.
+    pub num_mints: u64, // 8
+
+    /// Number of NFTs already minted from the mintlist.
+    pub mints_redeemed: u64, // 8
+
+    /// Order of going through the list of `MintInfo`'s during the minting process.
+    pub minting_order: MintingOrder, // 1
+
+    /// Optional pubkey of the collection the NFTs minted from the mintlist will belong to.
+    pub collection: Pubkey, // 32
+
+    pub created_at: i64, // 8
+
+    // FIXME: Figure out how to store the list of MintInfo's without explicitly
+    //        including it in the account type, to skip eager deserialization.
+    //        Can we use `AccountLoader` or shall we copy whatever CandyMachine does?
+}
+
+impl MintlistAccount {
+    pub fn size(num_mints: u64) -> usize {
+        // Account discriminator
+        8
+        // version
+        + 1
+        // creator
+        + 32
+        // treasury_sol
+        + 32
+        // go_live_date
+        + 8
+        // price
+        + 8
+        // num_mints
+        + 8
+        // mints_redeemed
+        + 8
+        // minting_order
+        + 1
+        // collection
+        + 32
+        // created_at
+        + 8
+        // mint_infos
+        // FIXME: When we figure out how to store the list of `MintInfo`'s, we might need to add the size of the container.
+        + (num_mints as usize) * MintInfo::size()
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum MintingOrder {
+    Sequential,
+    Random,
+}
+
+impl TryFrom<String> for MintingOrder {
+    type Error = NftokenError;
+    fn try_from(s: String) -> std::result::Result<Self, Self::Error> {
+        Ok(match s.as_ref() {
+            "sequential" => Self::Sequential,
+            "random" => Self::Random,
+            _ => return Err(NftokenError::InvalidMintingOrder),
+        })
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+pub struct MintInfo {
+    pub name: [u8; 32], // 32
+    pub image_url: [u8; 64], // 64
+    pub metadata_url: [u8; 64], // 64
+    pub minted: bool, // 1
+}
+
+impl MintInfo {
+    pub fn size() -> usize {
+        // name
+        32
+        // image_url
+        + 64
+        // metadata_url
+        + 64
+        // minted
+        + 1
+    }
+}
+
 

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -35,9 +35,10 @@ pub struct NftAccount {
     pub created_at: i64, // 8
 }
 
-#[account]
+#[account(zero_copy)]
 pub struct MintlistAccount {
     pub version: u8, // 1
+    _version_alignment: [u8; 7], // 7
 
     /// The pubkey that will be set as the creator of the NTFs minted from the mintlist.
     pub creator: Pubkey, // 32
@@ -59,6 +60,7 @@ pub struct MintlistAccount {
 
     /// Order of going through the list of `MintInfo`'s during the minting process.
     pub minting_order: MintingOrder, // 1
+    _minting_order_alignment: [u8; 7], // 7
 
     /// Optional pubkey of the collection the NFTs minted from the mintlist will belong to.
     pub collection: Pubkey, // 32
@@ -75,7 +77,7 @@ impl MintlistAccount {
         // Account discriminator
         8
         // version
-        + 1
+        + 8
         // creator
         + 32
         // treasury_sol
@@ -89,7 +91,7 @@ impl MintlistAccount {
         // mints_redeemed
         + 8
         // minting_order
-        + 1
+        + 8
         // collection
         + 32
         // created_at
@@ -100,7 +102,7 @@ impl MintlistAccount {
     }
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Copy)]
 #[non_exhaustive]
 pub enum MintingOrder {
     Sequential,

--- a/programs/nftoken/src/errors.rs
+++ b/programs/nftoken/src/errors.rs
@@ -2,10 +2,14 @@ use anchor_lang::prelude::*;
 
 #[error_code]
 pub enum NftokenError {
-    #[msg("You don't have permission to transfer this NFT.")]
+    #[msg("You don't have permission to transfer this NFT")]
     TransferUnauthorized,
-    #[msg("You don't have permission to delegate this NFT.")]
+    #[msg("You don't have permission to delegate this NFT")]
     DelegateUnauthorized,
-    #[msg("You are not authorized to perform this action.")]
+    #[msg("You are not authorized to perform this action")]
     Unauthorized,
+    #[msg("`mintlist` account is too small")]
+    MintlistAccountTooSmall,
+    #[msg("Invalid `minting_order`. Must be one of `sequential` or `random`")]
+    InvalidMintingOrder,
 }

--- a/programs/nftoken/src/errors.rs
+++ b/programs/nftoken/src/errors.rs
@@ -12,4 +12,6 @@ pub enum NftokenError {
     MintlistAccountTooSmall,
     #[msg("Invalid `minting_order`. Must be one of `sequential` or `random`")]
     InvalidMintingOrder,
+    #[msg("Too many `mint_infos`")]
+    TooManyMintInfos,
 }

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -33,7 +33,6 @@ pub fn mintlist_add_mint_infos_inner(
     for (i, mint_info_arg) in mint_infos.iter().enumerate() {
         let mint_info = MintInfo::from(mint_info_arg);
         mint_info.serialize(&mut &mut mintlist_data[insertion_byte_pos + i * mint_info_size..])?
-        // mintlist_account.mint_infos[usize::from(mint_infos_added) + i] = mint_info.into()
     }
 
     Ok(())

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -5,7 +5,7 @@ use crate::errors::*;
 
 /// Adds multiple `MintInfo`'s to the `mintlist`.
 pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> {
-    let mintlist_account = &mut ctx.accounts.mintlist;
+    // let mintlist_account = &mut ctx.accounts.mintlist;
     todo!()
     // Ok(())
 }
@@ -13,7 +13,7 @@ pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: M
 #[derive(Accounts)]
 pub struct MintlistAddMintInfos<'info> {
     #[account(mut, has_one = creator)]
-    mintlist: Account<'info, MintlistAccount>,
+    mintlist: AccountLoader<'info, MintlistAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -10,23 +10,24 @@ pub fn mintlist_add_mint_infos_inner(
 ) -> Result<()> {
     let mintlist_account = &mut ctx.accounts.mintlist.load_mut()?;
 
-    let added_len: u16 = mint_infos
+    let len_to_add: u16 = mint_infos
         .len()
         .try_into()
         .map_err(|_err| error!(NftokenError::TooManyMintInfos))?;
 
-    let available_mint_info_slots = mintlist_account.num_mints - mintlist_account.mint_infos_added;
+    let mint_infos_added = mintlist_account.mint_infos_added;
+    let available_mint_info_slots = mintlist_account.num_mints - mint_infos_added;
 
     require!(
-        added_len as u16 <= available_mint_info_slots,
+        len_to_add as u16 <= available_mint_info_slots,
         NftokenError::TooManyMintInfos
     );
 
     for (i, mint_info) in mint_infos.iter().enumerate() {
-        mintlist_account.mint_infos[usize::from(added_len) + i] = mint_info.into()
+        mintlist_account.mint_infos[usize::from(mint_infos_added) + i] = mint_info.into()
     }
 
-    mintlist_account.mint_infos_added += added_len;
+    mintlist_account.mint_infos_added += len_to_add;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -5,7 +5,7 @@ use crate::errors::*;
 
 /// Adds multiple `MintInfo`'s to the `mintlist`.
 pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> {
-    // let mintlist_account = &mut ctx.accounts.mintlist;
+    let mintlist_account = &mut ctx.accounts.mintlist.load_mut()?;
     todo!()
     // Ok(())
 }

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+use crate::account_types::*;
+use crate::errors::*;
+
+
+/// Adds multiple `MintInfo`'s to the `mintlist`.
+pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> {
+    let mintlist_account = &mut ctx.accounts.mintlist;
+    todo!()
+    // Ok(())
+}
+
+#[derive(Accounts)]
+pub struct MintlistAddMintInfos<'info> {
+    #[account(mut, has_one = creator)]
+    mintlist: Account<'info, MintlistAccount>,
+
+    #[account(mut)]
+    pub creator: Signer<'info>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+pub struct MintlistAddMintInfosArgs {
+
+}

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -8,26 +8,33 @@ pub fn mintlist_add_mint_infos_inner(
     ctx: Context<MintlistAddMintInfos>,
     mint_infos: Vec<MintInfoArg>,
 ) -> Result<()> {
-    let mintlist_account = &mut ctx.accounts.mintlist.load_mut()?;
+    let mintlist = &mut ctx.accounts.mintlist;
 
     let len_to_add: u16 = mint_infos
         .len()
         .try_into()
         .map_err(|_err| error!(NftokenError::TooManyMintInfos))?;
 
-    let mint_infos_added = mintlist_account.mint_infos_added;
-    let available_mint_info_slots = mintlist_account.num_mints - mint_infos_added;
+    let mint_infos_added = mintlist.mint_infos_added;
+    let available_mint_info_slots = mintlist.num_mints - mint_infos_added;
 
     require!(
         len_to_add as u16 <= available_mint_info_slots,
         NftokenError::TooManyMintInfos
     );
 
-    for (i, mint_info) in mint_infos.iter().enumerate() {
-        mintlist_account.mint_infos[usize::from(mint_infos_added) + i] = mint_info.into()
-    }
+    mintlist.mint_infos_added += len_to_add;
 
-    mintlist_account.mint_infos_added += len_to_add;
+    let mintlist_account_info = mintlist.to_account_info();
+    let mut mintlist_data = mintlist_account_info.data.borrow_mut();
+
+    let mint_info_size = MintInfo::size();
+    let insertion_byte_pos = MintlistAccount::size(mint_infos_added);
+    for (i, mint_info_arg) in mint_infos.iter().enumerate() {
+        let mint_info = MintInfo::from(mint_info_arg);
+        mint_info.serialize(&mut &mut mintlist_data[insertion_byte_pos + i * mint_info_size..])?
+        // mintlist_account.mint_infos[usize::from(mint_infos_added) + i] = mint_info.into()
+    }
 
     Ok(())
 }
@@ -35,7 +42,7 @@ pub fn mintlist_add_mint_infos_inner(
 #[derive(Accounts)]
 pub struct MintlistAddMintInfos<'info> {
     #[account(mut, has_one = creator)]
-    pub mintlist: AccountLoader<'info, MintlistAccount>,
+    pub mintlist: Account<'info, MintlistAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -1,25 +1,41 @@
-use anchor_lang::prelude::*;
 use crate::account_types::*;
 use crate::errors::*;
-
+use anchor_lang::prelude::*;
+use std::convert::TryInto;
 
 /// Adds multiple `MintInfo`'s to the `mintlist`.
-pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> {
+pub fn mintlist_add_mint_infos_inner(
+    ctx: Context<MintlistAddMintInfos>,
+    mint_infos: Vec<MintInfoArg>,
+) -> Result<()> {
     let mintlist_account = &mut ctx.accounts.mintlist.load_mut()?;
-    todo!()
-    // Ok(())
+
+    let added_len: u16 = mint_infos
+        .len()
+        .try_into()
+        .map_err(|_err| error!(NftokenError::TooManyMintInfos))?;
+
+    let available_mint_info_slots = mintlist_account.num_mints - mintlist_account.mint_infos_added;
+
+    require!(
+        added_len as u16 <= available_mint_info_slots,
+        NftokenError::TooManyMintInfos
+    );
+
+    for (i, mint_info) in mint_infos.iter().enumerate() {
+        mintlist_account.mint_infos[usize::from(added_len) + i] = mint_info.into()
+    }
+
+    mintlist_account.mint_infos_added += added_len;
+
+    Ok(())
 }
 
 #[derive(Accounts)]
 pub struct MintlistAddMintInfos<'info> {
     #[account(mut, has_one = creator)]
-    mintlist: AccountLoader<'info, MintlistAccount>,
+    pub mintlist: AccountLoader<'info, MintlistAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
-pub struct MintlistAddMintInfosArgs {
-
 }

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -50,7 +50,7 @@ pub struct MintlistCreateArgs {
     pub price: u64,
 
     /// Maximum number of NFTs that can be minted from the mintlist.
-    pub num_mints: u64,
+    pub num_mints: u16,
 
     /// Order of going through the list of `MintInfo`'s during the minting process.
     /// Can be "sequential" or "random".

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -1,12 +1,11 @@
-use std::convert::TryInto;
-use anchor_lang::prelude::*;
 use crate::account_types::*;
 use crate::errors::*;
-
+use anchor_lang::prelude::*;
+use std::convert::TryInto;
 
 /// # Create Mintlist
 pub fn mintlist_create_inner(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> {
-    let mintlist_account = &mut ctx.accounts.mintlist.load_init()?;
+    let mintlist_account = &mut ctx.accounts.mintlist;
 
     mintlist_account.version = 1;
     mintlist_account.creator = ctx.accounts.creator.key();
@@ -30,7 +29,7 @@ pub struct MintlistCreate<'info> {
         zero,
         constraint = mintlist.to_account_info().data_len() >= MintlistAccount::size(args.num_mints) @ NftokenError::MintlistAccountTooSmall
     )]
-    pub mintlist: AccountLoader<'info, MintlistAccount>,
+    pub mintlist: Account<'info, MintlistAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -6,7 +6,7 @@ use crate::errors::*;
 
 /// # Create Mintlist
 pub fn mintlist_create_inner(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> {
-    let mintlist_account = &mut ctx.accounts.mintlist;
+    let mintlist_account = &mut ctx.accounts.mintlist.load_init()?;
 
     mintlist_account.version = 1;
     mintlist_account.creator = ctx.accounts.creator.key();
@@ -30,7 +30,7 @@ pub struct MintlistCreate<'info> {
         zero,
         constraint = mintlist.to_account_info().data_len() >= MintlistAccount::size(args.num_mints) @ NftokenError::MintlistAccountTooSmall
     )]
-    pub mintlist: Account<'info, MintlistAccount>,
+    pub mintlist: AccountLoader<'info, MintlistAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -1,0 +1,58 @@
+use std::convert::TryInto;
+use anchor_lang::prelude::*;
+use crate::account_types::*;
+use crate::errors::*;
+
+
+/// # Create Mintlist
+pub fn mintlist_create_inner(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> {
+    let mintlist_account = &mut ctx.accounts.mintlist;
+
+    mintlist_account.version = 1;
+    mintlist_account.creator = ctx.accounts.creator.key();
+    mintlist_account.treasury_sol = args.treasury_sol;
+    mintlist_account.go_live_date = args.go_live_date;
+    mintlist_account.price = args.price;
+    mintlist_account.num_mints = args.num_mints;
+    mintlist_account.minting_order = args.minting_order.try_into()?;
+    mintlist_account.created_at = ctx.accounts.clock.unix_timestamp;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(args: MintlistCreateArgs)]
+pub struct MintlistCreate<'info> {
+    /// Due to the 10kb limit on the size of accounts that can be initialized via CPI,
+    /// the `mintlist` account must be initialized through a separate SystemProgram instruction,
+    /// that can be included into the same transaction as the `mintlist_create` instruction.
+    #[account(
+        zero,
+        constraint = mintlist.to_account_info().data_len() >= MintlistAccount::size(args.num_mints) @ NftokenError::MintlistAccountTooSmall
+    )]
+    pub mintlist: Account<'info, MintlistAccount>,
+
+    #[account(mut)]
+    pub creator: Signer<'info>,
+
+    pub clock: Sysvar<'info, Clock>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+pub struct MintlistCreateArgs {
+    /// SOL wallet to receive proceedings from SOL payments.
+    pub treasury_sol: Pubkey,
+
+    /// Timestamp when minting is allowed.
+    pub go_live_date: i64,
+
+    /// Price to pay for minting an NFT from the mintlist.
+    pub price: u64,
+
+    /// Maximum number of NFTs that can be minted from the mintlist.
+    pub num_mints: u64,
+
+    /// Order of going through the list of `MintInfo`'s during the minting process.
+    /// Can be "sequential" or "random".
+    pub minting_order: String,
+}

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -4,6 +4,8 @@ pub mod account_types;
 pub mod ix_collection_create;
 pub mod ix_collection_transfer;
 pub mod ix_collection_update;
+pub mod ix_mintlist_add_mint_infos;
+pub mod ix_mintlist_create;
 pub mod ix_nft_create;
 pub mod ix_nft_set_collection;
 pub mod ix_nft_set_delegate;
@@ -17,6 +19,8 @@ use anchor_lang::prelude::*;
 use crate::ix_collection_create::*;
 use crate::ix_collection_transfer::*;
 use crate::ix_collection_update::*;
+use crate::ix_mintlist_add_mint_infos::*;
+use crate::ix_mintlist_create::*;
 use crate::ix_nft_create::*;
 use crate::ix_nft_set_collection::*;
 use crate::ix_nft_set_delegate::*;
@@ -53,4 +57,9 @@ pub mod nftoken {
     pub fn collection_update(ctx: Context<CollectionUpdate>, name: [u8; 32], image_url: [u8; 64], metadata_url: [u8; 64], creator_can_update: bool) -> Result<()> { return collection_update_inner(ctx, name, image_url, metadata_url, creator_can_update); }
 
     pub fn transfer_collection(ctx: Context<CollectionTransferCreator>) -> Result<()> { return collection_transfer_creator_inner(ctx); }
+
+    // Mintlist instructions
+    pub fn mintlist_create(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> { return mintlist_create_inner(ctx, args); }
+
+    pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> { return mintlist_add_mint_infos_inner(ctx, args); }
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -108,7 +108,7 @@ pub mod nftoken {
         return mintlist_create_inner(ctx, args);
     }
 
-    pub fn mintlist_add_mint_infos_inner(
+    pub fn mintlist_add_mint_infos(
         ctx: Context<MintlistAddMintInfos>,
         mint_infos: Vec<MintInfoArg>,
     ) -> Result<()> {

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod account_types;
 pub mod constants;
 pub mod errors;
-pub mod account_types;
 pub mod ix_collection_create;
 pub mod ix_collection_transfer;
 pub mod ix_collection_update;
@@ -29,37 +29,89 @@ use crate::ix_nft_unset_collection::*;
 use crate::ix_nft_unset_delegate::*;
 use crate::ix_nft_update::*;
 
+use crate::account_types::*;
+
 declare_id!("nf2DH8Wq3uZdYEkqFqQ2LQ8rVJx6Lffw6jPa2JWBgXH");
 
 #[program]
 pub mod nftoken {
-    use crate::ix_collection_transfer::collection_transfer_creator_inner;
     use super::*;
+    use crate::ix_collection_transfer::collection_transfer_creator_inner;
 
     /// NFT Instructions
-    pub fn nft_create(ctx: Context<NftCreate>, name: [u8; 32], image_url: [u8; 64], metadata_url: [u8; 64], collection_included: bool) -> Result<()> { return nft_create_inner(ctx, name, image_url, metadata_url, collection_included); }
+    pub fn nft_create(
+        ctx: Context<NftCreate>,
+        name: [u8; 32],
+        image_url: [u8; 64],
+        metadata_url: [u8; 64],
+        collection_included: bool,
+    ) -> Result<()> {
+        return nft_create_inner(ctx, name, image_url, metadata_url, collection_included);
+    }
 
-    pub fn nft_update(ctx: Context<NftUpdate>, name: [u8; 32], image_url: [u8; 64], metadata_url: [u8; 64], creator_can_update: bool) -> Result<()> { return nft_update_inner(ctx, name, image_url, metadata_url, creator_can_update); }
+    pub fn nft_update(
+        ctx: Context<NftUpdate>,
+        name: [u8; 32],
+        image_url: [u8; 64],
+        metadata_url: [u8; 64],
+        creator_can_update: bool,
+    ) -> Result<()> {
+        return nft_update_inner(ctx, name, image_url, metadata_url, creator_can_update);
+    }
 
-    pub fn nft_transfer(ctx: Context<TransferNft>) -> Result<()> { return transfer_nft_inner(ctx); }
+    pub fn nft_transfer(ctx: Context<TransferNft>) -> Result<()> {
+        return transfer_nft_inner(ctx);
+    }
 
-    pub fn nft_set_delegate(ctx: Context<NftSetDelegate>) -> Result<()> { return nft_set_delegate_inner(ctx) }
+    pub fn nft_set_delegate(ctx: Context<NftSetDelegate>) -> Result<()> {
+        return nft_set_delegate_inner(ctx);
+    }
 
-    pub fn nft_unset_delegate(ctx: Context<NftUnsetDelegate>) -> Result<()> { return nft_unset_delegate_inner(ctx) }
+    pub fn nft_unset_delegate(ctx: Context<NftUnsetDelegate>) -> Result<()> {
+        return nft_unset_delegate_inner(ctx);
+    }
 
-    pub fn nft_set_collection(ctx: Context<NftSetCollection>) -> Result<()> { return nft_set_collection_inner(ctx) }
+    pub fn nft_set_collection(ctx: Context<NftSetCollection>) -> Result<()> {
+        return nft_set_collection_inner(ctx);
+    }
 
-    pub fn nft_unset_collection(ctx: Context<NftUnsetCollection>) -> Result<()> { return nft_unset_collection_inner(ctx) }
+    pub fn nft_unset_collection(ctx: Context<NftUnsetCollection>) -> Result<()> {
+        return nft_unset_collection_inner(ctx);
+    }
 
     /// Collection Instructions
-    pub fn collection_create(ctx: Context<CollectionCreate>, name: [u8; 32], image_url: [u8; 64], metadata_url: [u8; 64]) -> Result<()> { return collection_create_inner(ctx, name, image_url, metadata_url) }
+    pub fn collection_create(
+        ctx: Context<CollectionCreate>,
+        name: [u8; 32],
+        image_url: [u8; 64],
+        metadata_url: [u8; 64],
+    ) -> Result<()> {
+        return collection_create_inner(ctx, name, image_url, metadata_url);
+    }
 
-    pub fn collection_update(ctx: Context<CollectionUpdate>, name: [u8; 32], image_url: [u8; 64], metadata_url: [u8; 64], creator_can_update: bool) -> Result<()> { return collection_update_inner(ctx, name, image_url, metadata_url, creator_can_update); }
+    pub fn collection_update(
+        ctx: Context<CollectionUpdate>,
+        name: [u8; 32],
+        image_url: [u8; 64],
+        metadata_url: [u8; 64],
+        creator_can_update: bool,
+    ) -> Result<()> {
+        return collection_update_inner(ctx, name, image_url, metadata_url, creator_can_update);
+    }
 
-    pub fn transfer_collection(ctx: Context<CollectionTransferCreator>) -> Result<()> { return collection_transfer_creator_inner(ctx); }
+    pub fn transfer_collection(ctx: Context<CollectionTransferCreator>) -> Result<()> {
+        return collection_transfer_creator_inner(ctx);
+    }
 
     // Mintlist instructions
-    pub fn mintlist_create(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> { return mintlist_create_inner(ctx, args); }
+    pub fn mintlist_create(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> {
+        return mintlist_create_inner(ctx, args);
+    }
 
-    pub fn mintlist_add_mint_infos_inner(ctx: Context<MintlistAddMintInfos>, args: MintlistAddMintInfosArgs) -> Result<()> { return mintlist_add_mint_infos_inner(ctx, args); }
+    pub fn mintlist_add_mint_infos_inner(
+        ctx: Context<MintlistAddMintInfos>,
+        mint_infos: Vec<MintInfoArg>,
+    ) -> Result<()> {
+        return mintlist_add_mint_infos_inner(ctx, mint_infos);
+    }
 }

--- a/tests/mintlist-add-mint-infos.test.ts
+++ b/tests/mintlist-add-mint-infos.test.ts
@@ -1,8 +1,16 @@
+import assert from "assert";
 import * as anchor from "@project-serum/anchor";
 import { Program, web3, BN } from "@project-serum/anchor";
 import { Nftoken as NftokenTypes } from "../target/types/nftoken";
 import { createMintlist } from "./utils/create-mintlist";
-import { generateAlphaNumericString, strToArr } from "./utils/test-utils";
+import {
+  generateAlphaNumericString,
+  strToArr,
+  MintInfo,
+  nullArray32,
+  nullArray64,
+  arrayToStr,
+} from "./utils/test-utils";
 
 describe("mintlist_add_mint_infos", () => {
   const provider = anchor.AnchorProvider.env();
@@ -24,12 +32,88 @@ describe("mintlist_add_mint_infos", () => {
       program,
     });
 
-    // TODO
+    // This is maximum number of mintInfo's that fits in a transaction.
+    const batchSize = 6;
 
-    // const name = strToArr("Pesky Animals", 32);
-    // const image_url = strToArr(generateAlphaNumericString(16), 64);
-    // const metadata_url = strToArr(generateAlphaNumericString(16), 64);
-    //
-    // await program.methods.mintlistAddMintInfos([{ name }]);
+    // First batch.
+
+    const mintInfos1 = Array.from({ length: batchSize }, (_, i) => {
+      return createMintInfoArg(i);
+    });
+
+    await program.methods
+      .mintlistAddMintInfos(mintInfos1)
+      .accounts({
+        mintlist: mintlistAddress,
+        creator: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    let mintlistData = await program.account.mintlistAccount.fetch(
+      mintlistAddress
+    );
+
+    for (const [i, mintInfo] of (
+      mintlistData.mintInfos as MintInfo[]
+    ).entries()) {
+      if (i < batchSize) {
+        assert.deepEqual(mintInfo.name, mintInfos1[i].name);
+        assert.deepEqual(mintInfo.imageUrl, mintInfos1[i].imageUrl);
+        assert.deepEqual(mintInfo.metadataUrl, mintInfos1[i].metadataUrl);
+      } else {
+        // Check that the rest of the mintInfos are not populated.
+        assert.deepEqual(mintInfo.name, nullArray32);
+        assert.deepEqual(mintInfo.imageUrl, nullArray64);
+        assert.deepEqual(mintInfo.metadataUrl, nullArray64);
+      }
+    }
+
+    // Second batch.
+
+    const mintInfos2 = Array.from({ length: batchSize }, (_, i) => {
+      return createMintInfoArg(mintInfos1.length + i);
+    });
+
+    await program.methods
+      .mintlistAddMintInfos(mintInfos2)
+      .accounts({
+        mintlist: mintlistAddress,
+        creator: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    mintlistData = await program.account.mintlistAccount.fetch(mintlistAddress);
+
+    for (const [i, mintInfo] of (
+      mintlistData.mintInfos as MintInfo[]
+    ).entries()) {
+      if (i < batchSize) {
+        assert.deepEqual(mintInfo.name, mintInfos1[i].name);
+        assert.deepEqual(mintInfo.imageUrl, mintInfos1[i].imageUrl);
+        assert.deepEqual(mintInfo.metadataUrl, mintInfos1[i].metadataUrl);
+      } else if (i < batchSize * 2) {
+        assert.deepEqual(mintInfo.name, mintInfos2[i - batchSize].name);
+        assert.deepEqual(mintInfo.imageUrl, mintInfos2[i - batchSize].imageUrl);
+        assert.deepEqual(
+          mintInfo.metadataUrl,
+          mintInfos2[i - batchSize].metadataUrl
+        );
+      } else {
+        // Check that the rest of the mintInfos are not populated.
+        assert.deepEqual(mintInfo.name, nullArray32);
+        assert.deepEqual(mintInfo.imageUrl, nullArray64);
+        assert.deepEqual(mintInfo.metadataUrl, nullArray64);
+      }
+    }
+
+    // TODO: Test full population of the mintlist.
   });
 });
+
+function createMintInfoArg(index: number) {
+  return {
+    name: strToArr(`Pesky Animals #${index}`, 32),
+    imageUrl: strToArr(generateAlphaNumericString(16), 64),
+    metadataUrl: strToArr(generateAlphaNumericString(16), 64),
+  };
+}

--- a/tests/mintlist-add-mint-infos.test.ts
+++ b/tests/mintlist-add-mint-infos.test.ts
@@ -1,0 +1,35 @@
+import * as anchor from "@project-serum/anchor";
+import { Program, web3, BN } from "@project-serum/anchor";
+import { Nftoken as NftokenTypes } from "../target/types/nftoken";
+import { createMintlist } from "./utils/create-mintlist";
+import { generateAlphaNumericString, strToArr } from "./utils/test-utils";
+
+describe("mintlist_add_mint_infos", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.Nftoken as Program<NftokenTypes>;
+
+  it("should populate mintlist with mintInfo's", async () => {
+    const treasuryKeypair = web3.Keypair.generate();
+    const goLiveDate = new BN(Math.floor(Date.now() / 1000));
+    const price = new BN(web3.LAMPORTS_PER_SOL);
+    const numMints = 10000;
+
+    const { mintlistAddress } = await createMintlist({
+      treasury: treasuryKeypair.publicKey,
+      goLiveDate,
+      price,
+      numMints,
+      program,
+    });
+
+    // TODO
+
+    // const name = strToArr("Pesky Animals", 32);
+    // const image_url = strToArr(generateAlphaNumericString(16), 64);
+    // const metadata_url = strToArr(generateAlphaNumericString(16), 64);
+    //
+    // await program.methods.mintlistAddMintInfos([{ name }]);
+  });
+});

--- a/tests/mintlist-creation.test.ts
+++ b/tests/mintlist-creation.test.ts
@@ -14,11 +14,11 @@ describe("mintlist_create", () => {
     const treasuryKeypair = web3.Keypair.generate();
     const goLiveDate = new BN(Math.floor(Date.now() / 1000));
     const price = new BN(web3.LAMPORTS_PER_SOL);
-    const numMints = new BN(10000);
+    const numMints = 10000;
 
     const mintlistKeypair = web3.Keypair.generate();
 
-    const mintlistAccountSize = getMintlistAccountSize(numMints.toNumber());
+    const mintlistAccountSize = getMintlistAccountSize(numMints);
 
     const createMintlistAccountInstruction =
       anchor.web3.SystemProgram.createAccount({
@@ -37,7 +37,7 @@ describe("mintlist_create", () => {
         treasurySol: treasuryKeypair.publicKey,
         goLiveDate,
         price,
-        numMints: numMints,
+        numMints,
         mintingOrder: "sequential",
       })
       .accounts({
@@ -62,8 +62,8 @@ describe("mintlist_create", () => {
     assert.deepEqual(mintlistData.treasurySol, treasuryKeypair.publicKey);
     assert.deepEqual(mintlistData.goLiveDate.toNumber(), goLiveDate.toNumber());
     assert.equal(mintlistData.price.toNumber(), price.toNumber());
-    assert.deepEqual(mintlistData.numMints.toNumber(), numMints.toNumber());
-    assert.deepEqual(mintlistData.mintsRedeemed.toNumber(), 0);
+    assert.deepEqual(mintlistData.numMints, numMints);
+    assert.deepEqual(mintlistData.mintsRedeemed, 0);
     assert.deepEqual(mintlistData.mintingOrder, { sequential: {} });
     assert.deepEqual(mintlistData.collection, web3.PublicKey.default);
     assert(mintlistData.createdAt.toNumber() <= Date.now() / 1000);

--- a/tests/mintlist-creation.test.ts
+++ b/tests/mintlist-creation.test.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import * as anchor from "@project-serum/anchor";
 import { Program, web3, BN } from "@project-serum/anchor";
 import { Nftoken as NftokenTypes } from "../target/types/nftoken";
-import { createMintlist } from "./utils/create-mintlist";
+import { createMintlist } from "./utils/mintlist";
 
 describe("mintlist_create", () => {
   const provider = anchor.AnchorProvider.env();

--- a/tests/mintlist-creation.test.ts
+++ b/tests/mintlist-creation.test.ts
@@ -1,0 +1,71 @@
+import assert from "assert";
+import * as anchor from "@project-serum/anchor";
+import { Program, web3, BN } from "@project-serum/anchor";
+import { Nftoken as NftokenTypes } from "../target/types/nftoken";
+import { getMintlistAccountSize } from "./utils/create-mintlist";
+
+describe("mintlist_create", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.Nftoken as Program<NftokenTypes>;
+
+  it("should create a mintlist", async () => {
+    const treasuryKeypair = web3.Keypair.generate();
+    const goLiveDate = new BN(Math.floor(Date.now() / 1000));
+    const price = new BN(web3.LAMPORTS_PER_SOL);
+    const numMints = new BN(10000);
+
+    const mintlistKeypair = web3.Keypair.generate();
+
+    const mintlistAccountSize = getMintlistAccountSize(numMints.toNumber());
+
+    const createMintlistAccountInstruction =
+      anchor.web3.SystemProgram.createAccount({
+        fromPubkey: provider.wallet.publicKey,
+        newAccountPubkey: mintlistKeypair.publicKey,
+        space: mintlistAccountSize,
+        lamports:
+          await program.provider.connection.getMinimumBalanceForRentExemption(
+            mintlistAccountSize
+          ),
+        programId: program.programId,
+      });
+
+    await program.methods
+      .mintlistCreate({
+        treasurySol: treasuryKeypair.publicKey,
+        goLiveDate,
+        price,
+        numMints: numMints,
+        mintingOrder: "sequential",
+      })
+      .accounts({
+        mintlist: mintlistKeypair.publicKey,
+        creator: provider.wallet.publicKey,
+        clock: web3.SYSVAR_CLOCK_PUBKEY,
+      })
+      .signers([mintlistKeypair])
+      .preInstructions([createMintlistAccountInstruction])
+      .rpc()
+      .catch((e) => {
+        console.error(e.logs);
+        throw e;
+      });
+
+    const mintlistData = await program.account.mintlistAccount.fetch(
+      mintlistKeypair.publicKey
+    );
+
+    assert.equal(mintlistData.version, 1);
+    assert.deepEqual(mintlistData.creator, provider.wallet.publicKey);
+    assert.deepEqual(mintlistData.treasurySol, treasuryKeypair.publicKey);
+    assert.deepEqual(mintlistData.goLiveDate.toNumber(), goLiveDate.toNumber());
+    assert.equal(mintlistData.price.toNumber(), price.toNumber());
+    assert.deepEqual(mintlistData.numMints.toNumber(), numMints.toNumber());
+    assert.deepEqual(mintlistData.mintsRedeemed.toNumber(), 0);
+    assert.deepEqual(mintlistData.mintingOrder, { sequential: {} });
+    assert.deepEqual(mintlistData.collection, web3.PublicKey.default);
+    assert(mintlistData.createdAt.toNumber() <= Date.now() / 1000);
+  });
+});

--- a/tests/utils/IdlCoder.ts
+++ b/tests/utils/IdlCoder.ts
@@ -1,0 +1,169 @@
+/**
+ * This file is copy-pasted from the anchor codebase,
+ * because it's a private API which we should either ask to make public
+ * or
+ *
+ * @module
+ */
+
+import camelCase from "camelcase";
+import { Layout } from "buffer-layout";
+import * as borsh from "@project-serum/borsh";
+import {
+  IdlEnumVariant,
+  IdlField,
+  IdlType,
+  IdlTypeDef,
+} from "@project-serum/anchor/src/idl";
+import { IdlError } from "@project-serum/anchor";
+
+export class IdlCoder {
+  public static fieldLayout(
+    field: { name?: string } & Pick<IdlField, "type">,
+    types?: IdlTypeDef[]
+  ): Layout {
+    const fieldName =
+      field.name !== undefined ? camelCase(field.name) : undefined;
+    switch (field.type) {
+      case "bool": {
+        return borsh.bool(fieldName);
+      }
+      case "u8": {
+        return borsh.u8(fieldName);
+      }
+      case "i8": {
+        return borsh.i8(fieldName);
+      }
+      case "u16": {
+        return borsh.u16(fieldName);
+      }
+      case "i16": {
+        return borsh.i16(fieldName);
+      }
+      case "u32": {
+        return borsh.u32(fieldName);
+      }
+      case "i32": {
+        return borsh.i32(fieldName);
+      }
+      case "f32": {
+        return borsh.f32(fieldName);
+      }
+      case "u64": {
+        return borsh.u64(fieldName);
+      }
+      case "i64": {
+        return borsh.i64(fieldName);
+      }
+      case "f64": {
+        return borsh.f64(fieldName);
+      }
+      case "u128": {
+        return borsh.u128(fieldName);
+      }
+      case "i128": {
+        return borsh.i128(fieldName);
+      }
+      case "bytes": {
+        return borsh.vecU8(fieldName);
+      }
+      case "string": {
+        return borsh.str(fieldName);
+      }
+      case "publicKey": {
+        return borsh.publicKey(fieldName);
+      }
+      default: {
+        if ("vec" in field.type) {
+          return borsh.vec(
+            IdlCoder.fieldLayout(
+              {
+                name: undefined,
+                type: field.type.vec,
+              },
+              types
+            ),
+            fieldName
+          );
+        } else if ("option" in field.type) {
+          return borsh.option(
+            IdlCoder.fieldLayout(
+              {
+                name: undefined,
+                type: field.type.option,
+              },
+              types
+            ),
+            fieldName
+          );
+        } else if ("defined" in field.type) {
+          const defined = field.type.defined;
+          // User defined type.
+          if (types === undefined) {
+            throw new IdlError("User defined types not provided");
+          }
+          const filtered = types.filter((t) => t.name === defined);
+          if (filtered.length !== 1) {
+            throw new IdlError(`Type not found: ${JSON.stringify(field)}`);
+          }
+          return IdlCoder.typeDefLayout(filtered[0], types, fieldName);
+        } else if ("array" in field.type) {
+          let arrayTy = field.type.array[0];
+          let arrayLen = field.type.array[1];
+          let innerLayout = IdlCoder.fieldLayout(
+            {
+              name: undefined,
+              type: arrayTy,
+            },
+            types
+          );
+          return borsh.array(innerLayout, arrayLen, fieldName);
+        } else {
+          throw new Error(`Not yet implemented: ${field}`);
+        }
+      }
+    }
+  }
+
+  public static typeDefLayout(
+    typeDef: IdlTypeDef,
+    types: IdlTypeDef[] = [],
+    name?: string
+  ): Layout {
+    if (typeDef.type.kind === "struct") {
+      const fieldLayouts = typeDef.type.fields.map((field) => {
+        const x = IdlCoder.fieldLayout(field, types);
+        return x;
+      });
+      return borsh.struct(fieldLayouts, name);
+    } else if (typeDef.type.kind === "enum") {
+      let variants = typeDef.type.variants.map((variant: IdlEnumVariant) => {
+        const name = camelCase(variant.name);
+        if (variant.fields === undefined) {
+          return borsh.struct([], name);
+        }
+        const fieldLayouts = variant.fields.map((f: IdlField | IdlType) => {
+          if (!f.hasOwnProperty("name")) {
+            throw new Error("Tuple enum variants not yet implemented.");
+          }
+          // this typescript conversion is ok
+          // because if f were of type IdlType
+          // (that does not have a name property)
+          // the check before would've errored
+          return IdlCoder.fieldLayout(f as IdlField, types);
+        });
+        return borsh.struct(fieldLayouts, name);
+      });
+
+      if (name !== undefined) {
+        // Buffer-layout lib requires the name to be null (on construction)
+        // when used as a field.
+        return borsh.rustEnum(variants).replicate(name);
+      }
+
+      return borsh.rustEnum(variants, name);
+    } else {
+      throw new Error(`Unknown type kint: ${typeDef}`);
+    }
+  }
+}

--- a/tests/utils/IdlCoder.ts
+++ b/tests/utils/IdlCoder.ts
@@ -7,7 +7,10 @@
  */
 
 import camelCase from "camelcase";
+
+// @ts-ignore
 import { Layout } from "buffer-layout";
+
 import * as borsh from "@project-serum/borsh";
 import {
   IdlEnumVariant,

--- a/tests/utils/IdlCoder.ts
+++ b/tests/utils/IdlCoder.ts
@@ -1,7 +1,7 @@
 /**
  * This file is copy-pasted from the anchor codebase,
  * because it's a private API which we should either ask to make public
- * or
+ * or we can replace this with beet and our custom defined types.
  *
  * @module
  */

--- a/tests/utils/create-mintlist.ts
+++ b/tests/utils/create-mintlist.ts
@@ -1,0 +1,42 @@
+export function getMintlistAccountSize(numMints: number): number {
+  return (
+    // Account discriminator
+    8 +
+    // version
+    1 +
+    // creator
+    32 +
+    // treasury_sol
+    32 +
+    // go_live_date
+    8 +
+    // price
+    8 +
+    // num_mints
+    8 +
+    // mints_redeemed
+    8 +
+    // minting_order
+    1 +
+    // collection
+    32 +
+    // created_at
+    8 +
+    // mint_infos
+    // FIXME: When we figure out how to store the list of `MintInfo`'s, we might need to add the size of the container.
+    numMints * getMintInfoSize()
+  );
+}
+
+function getMintInfoSize(): number {
+  return (
+    // name
+    32 +
+    // image_url
+    64 +
+    // metadata_url
+    64 +
+    // minted
+    1
+  );
+}

--- a/tests/utils/create-mintlist.ts
+++ b/tests/utils/create-mintlist.ts
@@ -3,7 +3,7 @@ export function getMintlistAccountSize(numMints: number): number {
     // Account discriminator
     8 +
     // version
-    1 +
+    8 +
     // creator
     32 +
     // treasury_sol
@@ -17,7 +17,7 @@ export function getMintlistAccountSize(numMints: number): number {
     // mints_redeemed
     8 +
     // minting_order
-    1 +
+    8 +
     // collection
     32 +
     // created_at

--- a/tests/utils/create-mintlist.ts
+++ b/tests/utils/create-mintlist.ts
@@ -3,7 +3,15 @@ export function getMintlistAccountSize(numMints: number): number {
     // Account discriminator
     8 +
     // version
-    8 +
+    1 +
+    // minting_order
+    1 +
+    // num_mints
+    2 +
+    // mints_redeemed
+    2 +
+    // _alignment
+    2 +
     // creator
     32 +
     // treasury_sol
@@ -11,12 +19,6 @@ export function getMintlistAccountSize(numMints: number): number {
     // go_live_date
     8 +
     // price
-    8 +
-    // num_mints
-    8 +
-    // mints_redeemed
-    8 +
-    // minting_order
     8 +
     // collection
     32 +
@@ -37,6 +39,8 @@ function getMintInfoSize(): number {
     // metadata_url
     64 +
     // minted
-    1
+    1 +
+    // _alignment
+    7
   );
 }

--- a/tests/utils/create-mintlist.ts
+++ b/tests/utils/create-mintlist.ts
@@ -87,7 +87,6 @@ export function getMintlistAccountSize(numMints: number): number {
     // created_at
     8 +
     // mint_infos
-    // FIXME: When we figure out how to store the list of `MintInfo`'s, we might need to add the size of the container.
     numMints * getMintInfoSize()
   );
 }

--- a/tests/utils/test-utils.ts
+++ b/tests/utils/test-utils.ts
@@ -5,6 +5,13 @@ export const NULL_PUBKEY_STRING = "11111111111111111111111111111111";
 export type Base58 = string;
 export type Base64 = string;
 
+export const nullArray32 = nullArray(32);
+export const nullArray64 = nullArray(64);
+
+export function nullArray(length: number) {
+  return Array.from({ length }, () => 0);
+}
+
 export const strToArr = (str: string, length: number): Array<number> => {
   const buff = Buffer.alloc(length);
   buff.write(str, 0);
@@ -41,7 +48,13 @@ export type CollectionAccount = {
   metadataUrl: Array<number>;
 };
 
-const arrayToStr = (arr: Array<number>): string => {
+export type MintInfo = {
+  name: number[];
+  imageUrl: number[];
+  metadataUrl: number[];
+};
+
+export const arrayToStr = (arr: Array<number>): string => {
   const buffer = Buffer.from(arr);
   const str = buffer.toString("utf-8");
   return str.replace(/\0/g, "");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["@types/buffer-layout.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Related to #2

This creates a `MintlistAccount` struct along with instructions to:

- create / initialize the account
- add mint infos to the account

In the future, we will need to figure out:

- more instructions
  - mint NFT once the mintlist is ready
  - close the mintlist when the minting process is over (this will return the rent paid to create the mintlist)
- improve adding many NFTs at once
  - ensure that we aren't overwriting any existing NFTs
  - figure out what the maximum transaction size is