### PR TITLE
Improve `MintlistAccount` layout

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -3,7 +3,7 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.localnet]
-nftoken = "nf3AprLEeRuC3SawVf65ouNQrK6vjT95MdQPTSUY17r"
+nftoken = "nf4i4ZyQcYa3KbRnQDzBAncVpLJtS99aMEbjU2PwyKs"
 
 [scripts]
 test = "yarn jest"

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -9,12 +9,12 @@ pub fn collection_create_inner(
     ctx: Context<CollectionCreate>,
     args: CollectionCreateArgs,
 ) -> Result<()> {
-    let collection_account = &mut ctx.accounts.collection_account;
+    let collection = &mut ctx.accounts.collection;
 
-    collection_account.version = 1;
-    collection_account.creator = ctx.accounts.creator.key();
-    collection_account.metadata_url = args.metadata_url;
-    collection_account.creator_can_update = true;
+    collection.version = 1;
+    collection.creator = ctx.accounts.creator.key();
+    collection.metadata_url = args.metadata_url;
+    collection.creator_can_update = true;
 
     Ok(())
 }
@@ -23,7 +23,7 @@ pub fn collection_create_inner(
 #[instruction(args: CollectionCreateArgs)]
 pub struct CollectionCreate<'info> {
     #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
-    pub collection_account: Account<'info, CollectionAccount>,
+    pub collection: Account<'info, CollectionAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -9,12 +9,12 @@ pub fn collection_create_inner(
     ctx: Context<CollectionCreate>,
     args: CollectionCreateArgs,
 ) -> Result<()> {
-    let collection = &mut ctx.accounts.collection;
+    let collection_account = &mut ctx.accounts.collection_account;
 
-    collection.version = 1;
-    collection.creator = ctx.accounts.creator.key();
-    collection.metadata_url = args.metadata_url;
-    collection.creator_can_update = true;
+    collection_account.version = 1;
+    collection_account.creator = ctx.accounts.creator.key();
+    collection_account.metadata_url = args.metadata_url;
+    collection_account.creator_can_update = true;
 
     Ok(())
 }
@@ -23,7 +23,7 @@ pub fn collection_create_inner(
 #[instruction(args: CollectionCreateArgs)]
 pub struct CollectionCreate<'info> {
     #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
-    pub collection: Account<'info, CollectionAccount>,
+    pub collection_account: Account<'info, CollectionAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -9,12 +9,12 @@ pub fn collection_create_inner(
     ctx: Context<CollectionCreate>,
     args: CollectionCreateArgs,
 ) -> Result<()> {
-    let collection_account = &mut ctx.accounts.collection_account;
+    let collection = &mut ctx.accounts.collection;
 
-    collection_account.version = 1;
-    collection_account.creator = ctx.accounts.creator.key();
-    collection_account.metadata_url = args.metadata_url;
-    collection_account.creator_can_update = true;
+    collection.version = 1;
+    collection.creator = ctx.accounts.creator.key();
+    collection.metadata_url = args.metadata_url;
+    collection.creator_can_update = true;
 
     Ok(())
 }
@@ -26,7 +26,7 @@ pub struct CollectionCreate<'info> {
     pub creator: Signer<'info>,
 
     #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
-    pub collection_account: Account<'info, CollectionAccount>,
+    pub collection: Account<'info, CollectionAccount>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -22,11 +22,11 @@ pub fn collection_create_inner(
 #[derive(Accounts)]
 #[instruction(args: CollectionCreateArgs)]
 pub struct CollectionCreate<'info> {
-    #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
-    pub collection_account: Account<'info, CollectionAccount>,
-
     #[account(mut)]
     pub creator: Signer<'info>,
+
+    #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
+    pub collection_account: Account<'info, CollectionAccount>,
 
     pub system_program: Program<'info, System>,
 }

--- a/programs/nftoken/src/ix_collection_transfer.rs
+++ b/programs/nftoken/src/ix_collection_transfer.rs
@@ -1,27 +1,26 @@
-use anchor_lang::prelude::*;
 use crate::account_types::CollectionAccount;
 use crate::errors::NftokenError;
+use anchor_lang::prelude::*;
 
 /// This allows transferring the `creator` authority on a collection. When you transfer
 /// the `creator` you lose all privileges and the `new_creator` gets all of your permissions.
 pub fn collection_transfer_creator_inner(ctx: Context<CollectionTransferCreator>) -> Result<()> {
-    let collection_account = &mut ctx.accounts.collection_account;
+    let collection = &mut ctx.accounts.collection;
 
-    let action_allowed = collection_account.creator.key() == ctx.accounts.creator.key();
+    let action_allowed = collection.creator.key() == ctx.accounts.creator.key();
     require!(action_allowed, NftokenError::Unauthorized);
-    require!(collection_account.creator_can_update, NftokenError::Unauthorized);
+    require!(collection.creator_can_update, NftokenError::Unauthorized);
 
-    collection_account.creator = ctx.accounts.new_creator.key();
+    collection.creator = ctx.accounts.new_creator.key();
 
     Ok(())
 }
-
 
 #[derive(Accounts)]
 #[instruction()]
 pub struct CollectionTransferCreator<'info> {
     #[account(mut)]
-    pub collection_account: Account<'info, CollectionAccount>,
+    pub collection: Account<'info, CollectionAccount>,
 
     #[account(mut)]
     pub creator: Signer<'info>,

--- a/programs/nftoken/src/ix_collection_update.rs
+++ b/programs/nftoken/src/ix_collection_update.rs
@@ -9,17 +9,14 @@ pub fn collection_update_inner(
     ctx: Context<CollectionUpdate>,
     args: CollectionUpdateArgs,
 ) -> Result<()> {
-    let collection_account = &mut ctx.accounts.collection;
+    let collection = &mut ctx.accounts.collection;
 
-    let action_allowed = collection_account.creator.key() == ctx.accounts.creator.key();
+    let action_allowed = collection.creator.key() == ctx.accounts.creator.key();
     require!(action_allowed, NftokenError::Unauthorized);
-    require!(
-        collection_account.creator_can_update,
-        NftokenError::Unauthorized
-    );
+    require!(collection.creator_can_update, NftokenError::Unauthorized);
 
-    collection_account.metadata_url = args.metadata_url;
-    collection_account.creator_can_update = args.creator_can_update;
+    collection.metadata_url = args.metadata_url;
+    collection.creator_can_update = args.creator_can_update;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -10,13 +10,13 @@ pub fn mintlist_add_mint_infos_inner(
 ) -> Result<()> {
     let mintlist = &mut ctx.accounts.mintlist;
 
-    let len_to_add: u16 = mint_infos
+    let len_to_add: u32 = mint_infos
         .len()
         .try_into()
         .map_err(|_err| error!(NftokenError::TooManyMintInfos))?;
 
     let num_nfts_configured = mintlist.num_nfts_configured;
-    let available_mint_info_slots = mintlist.num_total_nfts - num_nfts_configured;
+    let available_mint_info_slots = mintlist.num_nfts_total - num_nfts_configured;
 
     require!(
         len_to_add <= available_mint_info_slots,

--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -3,6 +3,8 @@ use crate::errors::*;
 use anchor_lang::prelude::*;
 use std::convert::TryInto;
 
+/// # Mintlist - Add Mint Infos
+///
 /// Adds multiple `MintInfo`'s to the `mintlist`.
 pub fn mintlist_add_mint_infos_inner(
     ctx: Context<MintlistAddMintInfos>,

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -30,6 +30,9 @@ pub fn mintlist_create_inner(ctx: Context<MintlistCreate>, args: MintlistCreateA
 #[derive(Accounts)]
 #[instruction(args: MintlistCreateArgs)]
 pub struct MintlistCreate<'info> {
+    #[account(mut)]
+    pub creator: Signer<'info>,
+
     /// Due to the 10kb limit on the size of accounts that can be initialized via CPI,
     /// the `mintlist` account must be initialized through a separate SystemProgram instruction,
     /// that can be included into the same transaction as the `mintlist_create` instruction.
@@ -41,9 +44,6 @@ pub struct MintlistCreate<'info> {
 
     #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
     pub collection: Account<'info, CollectionAccount>,
-
-    #[account(mut)]
-    pub creator: Signer<'info>,
 
     /// SOL wallet to receive proceedings from SOL payments.
     /// CHECK: this can be any type

--- a/programs/nftoken/src/ix_mintlist_mint_nft.rs
+++ b/programs/nftoken/src/ix_mintlist_mint_nft.rs
@@ -93,7 +93,7 @@ fn get_mint_info_index(
             //    that corresponds to the `available_index`
             //
             // TODO: spend more time verifying this code since it was inspired by Metaplex Candy Machine
-            let nfts_available = mintlist.num_total_nfts - mintlist.num_nfts_redeemed;
+            let nfts_available = mintlist.num_nfts_total - mintlist.num_nfts_redeemed;
 
             let recent_hash_data = slothashes.data.borrow();
 
@@ -120,7 +120,7 @@ fn get_mint_info_index(
             let mut nft_index: usize = 0;
             let mut available_nfts_seen: usize = 0;
 
-            for _i in 0..mintlist.num_total_nfts {
+            for _i in 0..mintlist.num_nfts_total {
                 if mintlist_data[mint_info_pos] == 0 {
                     if available_nfts_seen == available_index {
                         break;

--- a/programs/nftoken/src/ix_nft_create.rs
+++ b/programs/nftoken/src/ix_nft_create.rs
@@ -10,7 +10,7 @@ use anchor_lang::prelude::*;
 ///
 /// If you want to let other people mint your NFTs, you should use the `Mintlist` feature.
 pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<()> {
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
 
     if args.collection_included {
         let collection_info: &AccountInfo = &ctx.remaining_accounts[0];
@@ -33,14 +33,14 @@ pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<
             NftokenError::Unauthorized
         );
 
-        nft.collection = *collection_info.key;
+        nft_account.collection = *collection_info.key;
     }
 
-    nft.version = 1;
-    nft.holder = ctx.accounts.holder.key();
-    nft.creator = ctx.accounts.holder.key();
-    nft.metadata_url = args.metadata_url;
-    nft.creator_can_update = true;
+    nft_account.version = 1;
+    nft_account.holder = ctx.accounts.holder.key();
+    nft_account.creator = ctx.accounts.holder.key();
+    nft_account.metadata_url = args.metadata_url;
+    nft_account.creator_can_update = true;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_create.rs
+++ b/programs/nftoken/src/ix_nft_create.rs
@@ -10,7 +10,7 @@ use anchor_lang::prelude::*;
 ///
 /// If you want to let other people mint your NFTs, you should use the `Mintlist` feature.
 pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
 
     if args.collection_included {
         let collection_info: &AccountInfo = &ctx.remaining_accounts[0];
@@ -20,7 +20,7 @@ pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<
         );
 
         let mut collection_data: &[u8] = &collection_info.try_borrow_data()?;
-        let collection_account = CollectionAccount::try_deserialize(&mut collection_data)?;
+        let collection = CollectionAccount::try_deserialize(&mut collection_data)?;
 
         let collection_authority_info = &ctx.remaining_accounts[1];
 
@@ -29,18 +29,18 @@ pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<
             NftokenError::Unauthorized
         );
         require!(
-            &collection_account.creator == collection_authority_info.key,
+            &collection.creator == collection_authority_info.key,
             NftokenError::Unauthorized
         );
 
-        nft_account.collection = *collection_info.key;
+        nft.collection = *collection_info.key;
     }
 
-    nft_account.version = 1;
-    nft_account.holder = ctx.accounts.holder.key();
-    nft_account.creator = ctx.accounts.holder.key();
-    nft_account.metadata_url = args.metadata_url;
-    nft_account.creator_can_update = true;
+    nft.version = 1;
+    nft.holder = ctx.accounts.holder.key();
+    nft.creator = ctx.accounts.holder.key();
+    nft.metadata_url = args.metadata_url;
+    nft.creator_can_update = true;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_create.rs
+++ b/programs/nftoken/src/ix_nft_create.rs
@@ -10,7 +10,7 @@ use anchor_lang::prelude::*;
 ///
 /// If you want to let other people mint your NFTs, you should use the `Mintlist` feature.
 pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
 
     if args.collection_included {
         let collection_info: &AccountInfo = &ctx.remaining_accounts[0];
@@ -33,14 +33,14 @@ pub fn nft_create_inner(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<
             NftokenError::Unauthorized
         );
 
-        nft_account.collection = *collection_info.key;
+        nft.collection = *collection_info.key;
     }
 
-    nft_account.version = 1;
-    nft_account.holder = ctx.accounts.holder.key();
-    nft_account.creator = ctx.accounts.holder.key();
-    nft_account.metadata_url = args.metadata_url;
-    nft_account.creator_can_update = true;
+    nft.version = 1;
+    nft.holder = ctx.accounts.holder.key();
+    nft.creator = ctx.accounts.holder.key();
+    nft.metadata_url = args.metadata_url;
+    nft.creator_can_update = true;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_set_collection.rs
+++ b/programs/nftoken/src/ix_nft_set_collection.rs
@@ -1,6 +1,6 @@
-use crate::account_types::{CollectionAccount, NftAccount};
-use crate::errors::*;
 use anchor_lang::prelude::*;
+use crate::errors::*;
+use crate::account_types::{CollectionAccount, NftAccount};
 
 /// # Set Collection
 ///
@@ -16,20 +16,19 @@ use anchor_lang::prelude::*;
 /// - `creator_can_update` = true
 /// - `creator == collection_authority` - the `collection.creator` has to sign this TX
 pub fn nft_set_collection_inner(ctx: Context<NftSetCollection>) -> Result<()> {
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
     let nft_authority_key = ctx.accounts.nft_authority.key();
 
-    let has_nft_auth = nft.creator.key() == nft_authority_key && nft.creator_can_update;
+    let has_nft_auth = nft_account.creator.key() == nft_authority_key && nft_account.creator_can_update;
     require!(has_nft_auth, NftokenError::Unauthorized);
 
     let collection_account = &ctx.accounts.collection;
     let collection_authority_key = ctx.accounts.collection_authority.key();
 
-    let has_collection_auth = collection_account.creator.key() == collection_authority_key
-        && collection_account.creator_can_update;
-    require!(has_collection_auth, NftokenError::Unauthorized);
+    let has_collection_auth = collection_account.creator.key() == collection_authority_key && collection_account.creator_can_update;
+    require!(has_collection_auth , NftokenError::Unauthorized);
 
-    nft.collection = collection_account.key();
+    nft_account.collection = collection_account.key();
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_set_collection.rs
+++ b/programs/nftoken/src/ix_nft_set_collection.rs
@@ -1,6 +1,6 @@
-use anchor_lang::prelude::*;
-use crate::errors::*;
 use crate::account_types::{CollectionAccount, NftAccount};
+use crate::errors::*;
+use anchor_lang::prelude::*;
 
 /// # Set Collection
 ///
@@ -16,19 +16,20 @@ use crate::account_types::{CollectionAccount, NftAccount};
 /// - `creator_can_update` = true
 /// - `creator == collection_authority` - the `collection.creator` has to sign this TX
 pub fn nft_set_collection_inner(ctx: Context<NftSetCollection>) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
     let nft_authority_key = ctx.accounts.nft_authority.key();
 
-    let has_nft_auth = nft_account.creator.key() == nft_authority_key && nft_account.creator_can_update;
+    let has_nft_auth = nft.creator.key() == nft_authority_key && nft.creator_can_update;
     require!(has_nft_auth, NftokenError::Unauthorized);
 
     let collection_account = &ctx.accounts.collection;
     let collection_authority_key = ctx.accounts.collection_authority.key();
 
-    let has_collection_auth = collection_account.creator.key() == collection_authority_key && collection_account.creator_can_update;
-    require!(has_collection_auth , NftokenError::Unauthorized);
+    let has_collection_auth = collection_account.creator.key() == collection_authority_key
+        && collection_account.creator_can_update;
+    require!(has_collection_auth, NftokenError::Unauthorized);
 
-    nft_account.collection = collection_account.key();
+    nft.collection = collection_account.key();
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_set_collection.rs
+++ b/programs/nftoken/src/ix_nft_set_collection.rs
@@ -1,6 +1,6 @@
-use anchor_lang::prelude::*;
-use crate::errors::*;
 use crate::account_types::{CollectionAccount, NftAccount};
+use crate::errors::*;
+use anchor_lang::prelude::*;
 
 /// # Set Collection
 ///
@@ -16,19 +16,20 @@ use crate::account_types::{CollectionAccount, NftAccount};
 /// - `creator_can_update` = true
 /// - `creator == collection_authority` - the `collection.creator` has to sign this TX
 pub fn nft_set_collection_inner(ctx: Context<NftSetCollection>) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
     let nft_authority_key = ctx.accounts.nft_authority.key();
 
-    let has_nft_auth = nft_account.creator.key() == nft_authority_key && nft_account.creator_can_update;
+    let has_nft_auth = nft.creator.key() == nft_authority_key && nft.creator_can_update;
     require!(has_nft_auth, NftokenError::Unauthorized);
 
-    let collection_account = &ctx.accounts.collection;
+    let collection = &ctx.accounts.collection;
     let collection_authority_key = ctx.accounts.collection_authority.key();
 
-    let has_collection_auth = collection_account.creator.key() == collection_authority_key && collection_account.creator_can_update;
-    require!(has_collection_auth , NftokenError::Unauthorized);
+    let has_collection_auth =
+        collection.creator.key() == collection_authority_key && collection.creator_can_update;
+    require!(has_collection_auth, NftokenError::Unauthorized);
 
-    nft_account.collection = collection_account.key();
+    nft.collection = collection.key();
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_set_delegate.rs
+++ b/programs/nftoken/src/ix_nft_set_delegate.rs
@@ -12,13 +12,13 @@ use crate::errors::*;
 /// the NFT to themselves and take control.
 pub fn nft_set_delegate_inner(ctx: Context<NftSetDelegate>) -> Result<()> {
     let holder = &ctx.accounts.holder;
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
 
-    let action_allowed = nft_account.holder.key() == holder.key();
+    let action_allowed = nft.holder.key() == holder.key();
     require!(action_allowed, NftokenError::Unauthorized);
 
     let delegate = ctx.accounts.delegate.key();
-    nft_account.delegate = delegate;
+    nft.delegate = delegate;
 
     Ok(())
 }
@@ -36,5 +36,3 @@ pub struct NftSetDelegate<'info> {
     /// CHECK: the delegate can be any account type
     pub delegate: AccountInfo<'info>,
 }
-
-

--- a/programs/nftoken/src/ix_nft_set_delegate.rs
+++ b/programs/nftoken/src/ix_nft_set_delegate.rs
@@ -12,13 +12,13 @@ use crate::errors::*;
 /// the NFT to themselves and take control.
 pub fn nft_set_delegate_inner(ctx: Context<NftSetDelegate>) -> Result<()> {
     let holder = &ctx.accounts.holder;
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
 
-    let action_allowed = nft.holder.key() == holder.key();
+    let action_allowed = nft_account.holder.key() == holder.key();
     require!(action_allowed, NftokenError::Unauthorized);
 
     let delegate = ctx.accounts.delegate.key();
-    nft.delegate = delegate;
+    nft_account.delegate = delegate;
 
     Ok(())
 }
@@ -36,3 +36,5 @@ pub struct NftSetDelegate<'info> {
     /// CHECK: the delegate can be any account type
     pub delegate: AccountInfo<'info>,
 }
+
+

--- a/programs/nftoken/src/ix_nft_transfer.rs
+++ b/programs/nftoken/src/ix_nft_transfer.rs
@@ -1,7 +1,7 @@
+use anchor_lang::prelude::*;
 use crate::account_types::*;
 use crate::constants::*;
 use crate::errors::*;
-use anchor_lang::prelude::*;
 
 /// Transfer an NFT to a different owner
 ///
@@ -9,13 +9,13 @@ use anchor_lang::prelude::*;
 pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
     // TODO check that you are either the delegate or the owner
     let signer = &ctx.accounts.signer;
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
 
-    let delegate = nft.delegate;
+    let delegate = nft_account.delegate;
 
     let transfer_allowed =
         // The NFT holder can make a transfer
-        nft.holder.key() == signer.key()
+        nft_account.holder.key() == signer.key()
             // So can the delegate, if the delegate is set.
             || delegate.key() == signer.key();
 
@@ -24,8 +24,8 @@ pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
     require!(recipient != NULL_PUBKEY, NftokenError::TransferUnauthorized);
     require!(transfer_allowed, NftokenError::TransferUnauthorized);
 
-    nft.holder = recipient;
-    nft.delegate = NULL_PUBKEY;
+    nft_account.holder = recipient;
+    nft_account.delegate = NULL_PUBKEY;
 
     Ok(())
 }
@@ -42,3 +42,4 @@ pub struct TransferNft<'info> {
     /// CHECK: this can be any type
     pub recipient: AccountInfo<'info>,
 }
+

--- a/programs/nftoken/src/ix_nft_transfer.rs
+++ b/programs/nftoken/src/ix_nft_transfer.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
 use crate::account_types::*;
 use crate::constants::*;
 use crate::errors::*;
+use anchor_lang::prelude::*;
 
 /// Transfer an NFT to a different owner
 ///
@@ -9,13 +9,13 @@ use crate::errors::*;
 pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
     // TODO check that you are either the delegate or the owner
     let signer = &ctx.accounts.signer;
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
 
-    let delegate = nft_account.delegate;
+    let delegate = nft.delegate;
 
     let transfer_allowed =
         // The NFT holder can make a transfer
-        nft_account.holder.key() == signer.key()
+        nft.holder.key() == signer.key()
             // So can the delegate, if the delegate is set.
             || delegate.key() == signer.key();
 
@@ -24,8 +24,8 @@ pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
     require!(recipient != NULL_PUBKEY, NftokenError::TransferUnauthorized);
     require!(transfer_allowed, NftokenError::TransferUnauthorized);
 
-    nft_account.holder = recipient;
-    nft_account.delegate = NULL_PUBKEY;
+    nft.holder = recipient;
+    nft.delegate = NULL_PUBKEY;
 
     Ok(())
 }
@@ -42,4 +42,3 @@ pub struct TransferNft<'info> {
     /// CHECK: this can be any type
     pub recipient: AccountInfo<'info>,
 }
-

--- a/programs/nftoken/src/ix_nft_unset_collection.rs
+++ b/programs/nftoken/src/ix_nft_unset_collection.rs
@@ -1,7 +1,7 @@
-use crate::account_types::NftAccount;
-use crate::constants::*;
-use crate::errors::*;
 use anchor_lang::prelude::*;
+use crate::errors::*;
+use crate::constants::*;
+use crate::account_types::{NftAccount};
 
 /// # Unset Collection
 ///
@@ -19,13 +19,13 @@ use anchor_lang::prelude::*;
 /// In the future, we may want to allow the collection authority to remove NFTs from a collection
 /// without auth from the NFT creator.
 pub fn nft_unset_collection_inner(ctx: Context<NftUnsetCollection>) -> Result<()> {
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
     let nft_authority_key = ctx.accounts.nft_authority.key();
 
-    let has_nft_auth = nft.creator.key() == nft_authority_key && nft.creator_can_update;
+    let has_nft_auth = nft_account.creator.key() == nft_authority_key && nft_account.creator_can_update;
     require!(has_nft_auth, NftokenError::Unauthorized);
 
-    nft.collection = NULL_PUBKEY;
+    nft_account.collection = NULL_PUBKEY;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_unset_collection.rs
+++ b/programs/nftoken/src/ix_nft_unset_collection.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
-use crate::errors::*;
+use crate::account_types::NftAccount;
 use crate::constants::*;
-use crate::account_types::{NftAccount};
+use crate::errors::*;
+use anchor_lang::prelude::*;
 
 /// # Unset Collection
 ///
@@ -19,13 +19,13 @@ use crate::account_types::{NftAccount};
 /// In the future, we may want to allow the collection authority to remove NFTs from a collection
 /// without auth from the NFT creator.
 pub fn nft_unset_collection_inner(ctx: Context<NftUnsetCollection>) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
     let nft_authority_key = ctx.accounts.nft_authority.key();
 
-    let has_nft_auth = nft_account.creator.key() == nft_authority_key && nft_account.creator_can_update;
+    let has_nft_auth = nft.creator.key() == nft_authority_key && nft.creator_can_update;
     require!(has_nft_auth, NftokenError::Unauthorized);
 
-    nft_account.collection = NULL_PUBKEY;
+    nft.collection = NULL_PUBKEY;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -6,14 +6,14 @@ use anchor_lang::prelude::*;
 ///
 /// Update the nft information on chain.
 pub fn nft_update_inner(ctx: Context<NftUpdate>, args: NftUpdateArgs) -> Result<()> {
-    let nft = &mut ctx.accounts.nft;
+    let nft_account = &mut ctx.accounts.nft;
 
-    let action_allowed = nft.creator.key() == ctx.accounts.creator.key();
+    let action_allowed = nft_account.creator.key() == ctx.accounts.creator.key();
     require!(action_allowed, NftokenError::Unauthorized);
-    require!(nft.creator_can_update, NftokenError::Unauthorized);
+    require!(nft_account.creator_can_update, NftokenError::Unauthorized);
 
-    nft.metadata_url = args.metadata_url;
-    nft.creator_can_update = args.creator_can_update;
+    nft_account.metadata_url = args.metadata_url;
+    nft_account.creator_can_update = args.creator_can_update;
 
     Ok(())
 }

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -6,14 +6,14 @@ use anchor_lang::prelude::*;
 ///
 /// Update the nft information on chain.
 pub fn nft_update_inner(ctx: Context<NftUpdate>, args: NftUpdateArgs) -> Result<()> {
-    let nft_account = &mut ctx.accounts.nft;
+    let nft = &mut ctx.accounts.nft;
 
-    let action_allowed = nft_account.creator.key() == ctx.accounts.creator.key();
+    let action_allowed = nft.creator.key() == ctx.accounts.creator.key();
     require!(action_allowed, NftokenError::Unauthorized);
-    require!(nft_account.creator_can_update, NftokenError::Unauthorized);
+    require!(nft.creator_can_update, NftokenError::Unauthorized);
 
-    nft_account.metadata_url = args.metadata_url;
-    nft_account.creator_can_update = args.creator_can_update;
+    nft.metadata_url = args.metadata_url;
+    nft.creator_can_update = args.creator_can_update;
 
     Ok(())
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -33,7 +33,7 @@ use crate::ix_nft_update::*;
 
 use crate::account_types::*;
 
-declare_id!("nf3AprLEeRuC3SawVf65ouNQrK6vjT95MdQPTSUY17r");
+declare_id!("nf4i4ZyQcYa3KbRnQDzBAncVpLJtS99aMEbjU2PwyKs");
 
 #[program]
 pub mod nftoken {

--- a/tests/mintlist-add-mint-infos.test.ts
+++ b/tests/mintlist-add-mint-infos.test.ts
@@ -19,13 +19,13 @@ describe("mintlist_add_mint_infos", () => {
     const treasuryKeypair = web3.Keypair.generate();
     const goLiveDate = new BN(Math.floor(Date.now() / 1000));
     const price = new BN(web3.LAMPORTS_PER_SOL);
-    const numTotalNfts = 1000;
+    const numNftsTotal = 1000;
 
     const { mintlistAddress } = await createEmptyMintlist({
       treasury: treasuryKeypair.publicKey,
       goLiveDate,
       price,
-      numTotalNfts,
+      numNftsTotal,
       program,
     });
 

--- a/tests/mintlist-creation.test.ts
+++ b/tests/mintlist-creation.test.ts
@@ -32,7 +32,6 @@ describe("mintlist_create", () => {
     assert.deepEqual(mintlistData.numNftsTotal, numNftsTotal);
     assert.deepEqual(mintlistData.numNftsRedeemed, 0);
     assert.deepEqual(mintlistData.mintingOrder, { sequential: {} });
-    assert.deepEqual(mintlistData.collection, web3.PublicKey.default);
     assert(mintlistData.createdAt.toNumber() <= Date.now() / 1000);
   });
 });

--- a/tests/mintlist-creation.test.ts
+++ b/tests/mintlist-creation.test.ts
@@ -14,13 +14,13 @@ describe("mintlist_create", () => {
     const treasuryKeypair = web3.Keypair.generate();
     const goLiveDate = new BN(Math.floor(Date.now() / 1000));
     const price = new BN(web3.LAMPORTS_PER_SOL);
-    const numTotalNfts = 10000;
+    const numNftsTotal = 10000;
 
     const { mintlistData } = await createEmptyMintlist({
       treasury: treasuryKeypair.publicKey,
       goLiveDate,
       price,
-      numTotalNfts,
+      numNftsTotal,
       program,
     });
 
@@ -29,7 +29,7 @@ describe("mintlist_create", () => {
     assert.deepEqual(mintlistData.treasurySol, treasuryKeypair.publicKey);
     assert.deepEqual(mintlistData.goLiveDate.toNumber(), goLiveDate.toNumber());
     assert.equal(mintlistData.price.toNumber(), price.toNumber());
-    assert.deepEqual(mintlistData.numTotalNfts, numTotalNfts);
+    assert.deepEqual(mintlistData.numNftsTotal, numNftsTotal);
     assert.deepEqual(mintlistData.numNftsRedeemed, 0);
     assert.deepEqual(mintlistData.mintingOrder, { sequential: {} });
     assert.deepEqual(mintlistData.collection, web3.PublicKey.default);

--- a/tests/mintlist-mint-nft.test.ts
+++ b/tests/mintlist-mint-nft.test.ts
@@ -16,13 +16,13 @@ describe("mintlist_mint_nft", () => {
     const treasuryKeypair = web3.Keypair.generate();
     const goLiveDate = new BN(0);
     const price = new BN(web3.LAMPORTS_PER_SOL);
-    const numTotalNfts = 1;
+    const numNftsTotal = 1;
 
     const { mintlistAddress } = await createEmptyMintlist({
       treasury: treasuryKeypair.publicKey,
       goLiveDate,
       price,
-      numTotalNfts,
+      numNftsTotal,
       program,
     });
 
@@ -84,7 +84,7 @@ describe("mintlist_mint_nft", () => {
 
     const signer = anchor.AnchorProvider.local().wallet.publicKey;
 
-    for (const _idx of _.range(initialMintlistData.numTotalNfts)) {
+    for (const _idx of _.range(initialMintlistData.numNftsTotal)) {
       const nftKeypair = Keypair.generate();
 
       // Mint an NFT!

--- a/tests/utils/create-collection.ts
+++ b/tests/utils/create-collection.ts
@@ -33,7 +33,7 @@ export const createCollection = async ({
   const signature = await program.methods
     .collectionCreate({ metadataUrl })
     .accounts({
-      collection: collection_keypair.publicKey,
+      collectionAccount: collection_keypair.publicKey,
       creator,
       systemProgram: SystemProgram.programId,
     })

--- a/tests/utils/create-collection.ts
+++ b/tests/utils/create-collection.ts
@@ -33,7 +33,7 @@ export const createCollection = async ({
   const signature = await program.methods
     .collectionCreate({ metadataUrl })
     .accounts({
-      collectionAccount: collection_keypair.publicKey,
+      collection: collection_keypair.publicKey,
       creator,
       systemProgram: SystemProgram.programId,
     })

--- a/tests/utils/mintlist.ts
+++ b/tests/utils/mintlist.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import * as anchor from "@project-serum/anchor";
 import { BN, Program, web3 } from "@project-serum/anchor";
 import { Nftoken as NftokenTypes, IDL } from "../../target/types/nftoken";
-import { PublicKey, SystemProgram } from "@solana/web3.js";
+import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import { createMintInfoArg } from "../mintlist-add-mint-infos.test";
 import { IdlCoder } from "./IdlCoder";
 import { arrayToStr, strToArr } from "./test-utils";
@@ -47,6 +47,8 @@ export async function createEmptyMintlist({
       programId: program.programId,
     });
 
+  const collectionKeypair = Keypair.generate();
+
   await program.methods
     .mintlistCreate({
       goLiveDate,
@@ -57,13 +59,14 @@ export async function createEmptyMintlist({
       collectionMetadataUrl: strToArr("coll-random-meta", 64),
     })
     .accounts({
+      collection: collectionKeypair.publicKey,
       mintlist: mintlistKeypair.publicKey,
       creator: wallet.publicKey,
       clock: web3.SYSVAR_CLOCK_PUBKEY,
       treasurySol: treasury,
       systemProgram: SystemProgram.programId,
     })
-    .signers([mintlistKeypair])
+    .signers([mintlistKeypair, collectionKeypair])
     .preInstructions([createMintlistAccountInstruction])
     .rpc()
     .catch((e) => {

--- a/tests/utils/mintlist.ts
+++ b/tests/utils/mintlist.ts
@@ -53,8 +53,8 @@ export async function createEmptyMintlist({
       price,
       numNftsTotal,
       mintingOrder,
-      metadataUrl: strToArr('random-meta', 64),
-      collectionMetadataUrl: strToArr('coll-random-meta', 64),
+      metadataUrl: strToArr("random-meta", 64),
+      collectionMetadataUrl: strToArr("coll-random-meta", 64),
     })
     .accounts({
       mintlist: mintlistKeypair.publicKey,
@@ -137,30 +137,19 @@ export async function getMintlistData({
 
 export function getMintlistAccountSize(numNftsTotal: number): number {
   return (
-    // Account discriminator
     8 +
-    // version
     1 +
-    // creator
     32 +
-    // treasury_sol
     32 +
-    // go_live_date
     8 +
-    // price
     8 +
-    // minting_order
     1 +
-    // num_mints
-    2 +
-    // mints_redeemed
-    2 +
-    // _alignment
-    2 +
-    // collection
     32 +
-    // created_at
+    64 +
     8 +
+    4 +
+    4 +
+    4 +
     // mint_infos
     numNftsTotal * MINT_INFO_LAYOUT.span
   );


### PR DESCRIPTION
Changes:

1. create `collection` when creating `mintlist`
2. store `mintlist.metadata_url`
3. make `mintlist.mint_infos` parseable as a `Vec<MintInfo>` by storing `num_nfts_configured` right before the list of `MintInfo`
4. renames `collection_account` and `nft_account` params to `collection` and `nft`