### PR TITLE
Prevent adding duplicate mint infos

### DIFF
--- a/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
+++ b/programs/nftoken/src/ix_mintlist_add_mint_infos.rs
@@ -8,11 +8,20 @@ use std::convert::TryInto;
 /// Adds multiple `MintInfo`'s to the `mintlist`.
 pub fn mintlist_add_mint_infos_inner(
     ctx: Context<MintlistAddMintInfos>,
-    mint_infos: Vec<MintInfoArg>,
+    args: MintlistAddMintInfosArgs,
 ) -> Result<()> {
     let mintlist = &mut ctx.accounts.mintlist;
 
-    let len_to_add: u32 = mint_infos
+    // We make this check to help ensure that someone doesn't create duplicate NFTs. Without this
+    // check if you retry a transaction to add 3 Mint Infos, you could add those Mint Infos more
+    // than once.
+    require!(
+        mintlist.num_nfts_configured == args.current_nft_count,
+        NftokenError::Unauthorized
+    );
+
+    let len_to_add: u32 = args
+        .mint_infos
         .len()
         .try_into()
         .map_err(|_err| error!(NftokenError::TooManyMintInfos))?;
@@ -32,7 +41,7 @@ pub fn mintlist_add_mint_infos_inner(
 
     let mint_info_size = MintInfo::size();
     let insertion_byte_pos = MintlistAccount::size(num_nfts_configured);
-    for (i, mint_info_arg) in mint_infos.iter().enumerate() {
+    for (i, mint_info_arg) in args.mint_infos.iter().enumerate() {
         let mint_info = MintInfo::from(mint_info_arg);
         mint_info.serialize(&mut &mut mintlist_data[insertion_byte_pos + i * mint_info_size..])?
     }
@@ -47,4 +56,10 @@ pub struct MintlistAddMintInfos<'info> {
 
     #[account(mut)]
     pub creator: Signer<'info>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
+pub struct MintlistAddMintInfosArgs {
+    pub current_nft_count: u32,
+    pub mint_infos: Vec<MintInfoArg>,
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 
-use crate::account_types::*;
 use crate::ix_collection_create::*;
 use crate::ix_collection_transfer::*;
 use crate::ix_collection_update::*;
@@ -39,6 +38,7 @@ pub mod nftoken {
     use super::*;
 
     /// NFT Instructions
+
     pub fn nft_create(ctx: Context<NftCreate>, args: NftCreateArgs) -> Result<()> {
         return nft_create_inner(ctx, args);
     }
@@ -68,6 +68,7 @@ pub mod nftoken {
     }
 
     /// Collection Instructions
+
     pub fn collection_create(
         ctx: Context<CollectionCreate>,
         args: CollectionCreateArgs,
@@ -86,16 +87,17 @@ pub mod nftoken {
         return collection_transfer_creator_inner(ctx);
     }
 
-    /// Mintlist instructions
+    /// Mintlist Instructions
+
     pub fn mintlist_create(ctx: Context<MintlistCreate>, args: MintlistCreateArgs) -> Result<()> {
         return mintlist_create_inner(ctx, args);
     }
 
     pub fn mintlist_add_mint_infos(
         ctx: Context<MintlistAddMintInfos>,
-        mint_infos: Vec<MintInfoArg>,
+        args: MintlistAddMintInfosArgs,
     ) -> Result<()> {
-        return mintlist_add_mint_infos_inner(ctx, mint_infos);
+        return mintlist_add_mint_infos_inner(ctx, args);
     }
 
     pub fn mintlist_mint_nft(ctx: Context<MintlistMintNft>) -> Result<()> {

--- a/tests/mintlist-add-mint-infos.test.ts
+++ b/tests/mintlist-add-mint-infos.test.ts
@@ -39,7 +39,7 @@ describe("mintlist_add_mint_infos", () => {
     });
 
     await program.methods
-      .mintlistAddMintInfos(mintInfos1)
+      .mintlistAddMintInfos({ currentNftCount: 0, mintInfos: mintInfos1 })
       .accounts({
         mintlist: mintlistAddress,
         creator: provider.wallet.publicKey,
@@ -66,8 +66,21 @@ describe("mintlist_add_mint_infos", () => {
       return createMintInfoArg(mintInfos1.length + i);
     });
 
+    await expect(async () => {
+      await program.methods
+        .mintlistAddMintInfos({ currentNftCount: 0, mintInfos: mintInfos2 })
+        .accounts({
+          mintlist: mintlistAddress,
+          creator: provider.wallet.publicKey,
+        })
+        .rpc();
+    }).rejects.toThrow();
+
     await program.methods
-      .mintlistAddMintInfos(mintInfos2)
+      .mintlistAddMintInfos({
+        currentNftCount: mintInfos1.length,
+        mintInfos: mintInfos2,
+      })
       .accounts({
         mintlist: mintlistAddress,
         creator: provider.wallet.publicKey,

--- a/tests/mintlist-mint-nft.test.ts
+++ b/tests/mintlist-mint-nft.test.ts
@@ -33,7 +33,7 @@ describe("mintlist_mint_nft", () => {
     const mintInfos = [createMintInfoArg(0)];
 
     await program.methods
-      .mintlistAddMintInfos(mintInfos)
+      .mintlistAddMintInfos({ currentNftCount: 0, mintInfos })
       .accounts({
         mintlist: mintlistAddress,
         creator: provider.wallet.publicKey,

--- a/tests/utils/mintlist.ts
+++ b/tests/utils/mintlist.ts
@@ -191,7 +191,7 @@ export async function createMintlistWithInfos({
   const { wallet } = anchor.AnchorProvider.local();
 
   await program.methods
-    .mintlistAddMintInfos(mintInfos)
+    .mintlistAddMintInfos({ currentNftCount: 0, mintInfos })
     .accounts({
       mintlist: mintlistAddress,
       creator: wallet.publicKey,


### PR DESCRIPTION
When we add mint infos, we must specify how many mint infos we have already configured.

We can use this to avoid adding duplicate mint infos. The most straightforward way to add 10k mint infos is to add 100 at a time. Then every time when we add another batch `b` of 100, we say that we expect to have added `b * 100` of mint infos already. If this instruction is retried in a different transaction, it will fail.