### PR TITLE
Update metadata length and account sizes

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -3,7 +3,7 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.localnet]
-nftoken = "nf4i4ZyQcYa3KbRnQDzBAncVpLJtS99aMEbjU2PwyKs"
+nftoken = "nft54LYxr6noyvwaQKChAmRpnvn6yZGZkFDtajPz3u8"
 
 [scripts]
 test = "pnpm --filter program-tests exec jest"

--- a/program-tests/collection-update.test.ts
+++ b/program-tests/collection-update.test.ts
@@ -15,7 +15,7 @@ describe("update collection", () => {
   test("properly updates metadata", async () => {
     const { collection_pubkey } = await createCollection({ program });
 
-    const metadata_url = strToArr("new-meta", 64);
+    const metadata_url = strToArr("new-meta", 96);
     const creator_can_update = true;
 
     const signature = await program.methods
@@ -42,7 +42,7 @@ describe("update collection", () => {
   test("doesn't allow update if !creator_can_update", async () => {
     const { collection_pubkey } = await createCollection({ program });
 
-    const metadata_url = strToArr("new-meta", 64);
+    const metadata_url = strToArr("new-meta", 96);
     const creator_can_update = false;
 
     const signature = await program.methods

--- a/program-tests/mintlist-add-mint-infos.test.ts
+++ b/program-tests/mintlist-add-mint-infos.test.ts
@@ -114,6 +114,6 @@ describe("mintlist_add_mint_infos", () => {
 
 export function createMintInfoArg(index: number) {
   return {
-    metadataUrl: strToArr(`${generateAlphaNumericString(16)}--${index}`, 64),
+    metadataUrl: strToArr(`${generateAlphaNumericString(16)}--${index}`, 96),
   };
 }

--- a/program-tests/nft-create.test.ts
+++ b/program-tests/nft-create.test.ts
@@ -38,7 +38,7 @@ describe("ix_nft_create", () => {
   test("mints an NFT into a collection", async () => {
     const { creator, collection_keypair } = await createCollection({ program });
 
-    const nft_metadata_url = strToArr("url2", 64);
+    const nft_metadata_url = strToArr("url2", 96);
 
     const nftKeypair = Keypair.generate();
 

--- a/program-tests/nft-update.test.ts
+++ b/program-tests/nft-update.test.ts
@@ -15,7 +15,7 @@ describe("update NFT", () => {
   test("properly updates metadata", async () => {
     const { nft_pubkey } = await createNft({ program });
 
-    const metadataUrl = strToArr("new-meta", 64);
+    const metadataUrl = strToArr("new-meta", 96);
     const creatorCanUpdate = true;
 
     const signature = await program.methods
@@ -37,7 +37,7 @@ describe("update NFT", () => {
   test("doesn't allow update if !creator_can_update", async () => {
     const { nft_pubkey } = await createNft({ program });
 
-    const metadataUrl = strToArr("new-meta", 64);
+    const metadataUrl = strToArr("new-meta", 96);
     const creatorCanUpdate = false;
 
     const signature = await program.methods

--- a/program-tests/utils/create-collection.ts
+++ b/program-tests/utils/create-collection.ts
@@ -23,7 +23,7 @@ export const createCollection = async ({
 }> => {
   const metadataUrl = strToArr(
     _metadata_url || generateAlphaNumericString(16),
-    64
+    96
   );
 
   const collection_keypair = Keypair.generate();

--- a/program-tests/utils/create-nft.ts
+++ b/program-tests/utils/create-nft.ts
@@ -24,7 +24,7 @@ export const createNft = async ({
 }> => {
   const metadata_url = strToArr(
     _metadata_url || generateAlphaNumericString(16),
-    64
+    96
   );
 
   const nftKeypair = Keypair.generate();

--- a/program-tests/utils/mintlist.ts
+++ b/program-tests/utils/mintlist.ts
@@ -55,8 +55,8 @@ export async function createEmptyMintlist({
       priceLamports,
       numNftsTotal,
       mintingOrder,
-      metadataUrl: strToArr("random-meta", 64),
-      collectionMetadataUrl: strToArr("coll-random-meta", 64),
+      metadataUrl: strToArr("random-meta", 96),
+      collectionMetadataUrl: strToArr("coll-random-meta", 96),
     })
     .accounts({
       collection: collectionKeypair.publicKey,
@@ -148,7 +148,7 @@ export function getMintlistAccountSize(numNftsTotal: number): number {
     8 +
     1 +
     32 +
-    64 +
+    96 +
     8 +
     4 +
     4 +

--- a/program-tests/utils/test-utils.ts
+++ b/program-tests/utils/test-utils.ts
@@ -3,10 +3,6 @@ import { Buffer } from "buffer";
 
 export const NULL_PUBKEY_STRING = "11111111111111111111111111111111";
 export type Base58 = string;
-export type Base64 = string;
-
-export const nullArray32 = nullArray(32);
-export const nullArray64 = nullArray(64);
 
 export function nullArray(length: number) {
   return Array.from({ length }, () => 0);

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -9,21 +9,32 @@ pub struct CollectionAccount {
     /// This versions the account so that we can store different data formats in the future.
     /// The first version is 1.
     pub version: u8, // 1
-    pub creator: Pubkey,          // 32
-    pub creator_can_update: bool, // 1
-    pub metadata_url: [u8; 64],   // 1
+    pub creator: Pubkey,          // 32 = 33
+    pub creator_can_update: bool, // 1 = 32
+    pub metadata_url: [u8; 96],   // 96 = 128
+                                  // Discriminator 8 = 136
 }
+
+pub const COLLECTION_ACCOUNT_SIZE: usize = 200;
 
 #[account]
 pub struct NftAccount {
     pub version: u8,              // 1
-    pub holder: Pubkey,           // 32
-    pub creator: Pubkey,          // 32
-    pub creator_can_update: bool, // 1
-    pub collection: Pubkey,       // 32
-    pub delegate: Pubkey,         // 32
-    pub metadata_url: [u8; 64],   // 64
+    pub holder: Pubkey,           // 32 = 33
+    pub creator: Pubkey,          // 32 = 65
+    pub creator_can_update: bool, // 1  = 66
+    pub collection: Pubkey,       // 32 = 98
+    /// If this is zero'd out (set to 11111...1111 in base58) then the NFT is not delegated.
+    pub delegate: Pubkey, // 32 = 130
+    pub metadata_url: [u8; 96],   // 96 = 226
+                                  // discriminator 8 = 234
+
+                                  // Possible things to add later:
+                                  // - transfer counter - u8
+                                  // - is frozen - u8 / bool
 }
+
+pub const NFT_ACCOUNT_SIZE: usize = 240;
 
 #[account]
 pub struct MintlistAccount {
@@ -48,7 +59,7 @@ pub struct MintlistAccount {
     pub collection: Pubkey,
 
     /// Metadata that stores name, avatar, etc of the mintlist
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
 
     /// Timestamp when the mintlist was created.
     pub created_at: i64,
@@ -121,7 +132,7 @@ impl MintlistAccount {
         // collection
         + 32
         // metadata_url
-        + 64
+        + 96
         // created_at
         + 8
         // num_mints
@@ -156,7 +167,7 @@ impl TryFrom<String> for MintingOrder {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct MintInfo {
     pub minted: bool,           // 1
-    pub metadata_url: [u8; 64], // 64
+    pub metadata_url: [u8; 96], // 96
 }
 
 impl MintInfo {
@@ -164,7 +175,7 @@ impl MintInfo {
         // minted
         1
         // metadata_url
-        + 64
+        + 96
     }
 }
 
@@ -179,5 +190,5 @@ impl From<&MintInfoArg> for MintInfo {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct MintInfoArg {
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
 }

--- a/programs/nftoken/src/constants.rs
+++ b/programs/nftoken/src/constants.rs
@@ -3,6 +3,3 @@ use anchor_lang::prelude::*;
 /// Note this is represented in base58 as `11111111111111111111111111111111` which is the same
 /// as the system program.
 pub const NULL_PUBKEY: Pubkey = Pubkey::new_from_array([0; 32]);
-
-pub const NFT_ACCOUNT_SIZE: usize = 220;
-pub const COLLECTION_ACCOUNT_SIZE: usize = 300;

--- a/programs/nftoken/src/errors.rs
+++ b/programs/nftoken/src/errors.rs
@@ -2,8 +2,6 @@ use anchor_lang::prelude::*;
 
 #[error_code]
 pub enum NftokenError {
-    #[msg("You don't have permission to transfer this NFT")]
-    TransferUnauthorized,
     #[msg("You don't have permission to delegate this NFT")]
     DelegateUnauthorized,
     #[msg("You are not authorized to perform this action")]

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -3,8 +3,7 @@
 //! This creates a *collection* account which NFTs can be associated with.
 use anchor_lang::prelude::*;
 
-use crate::account_types::CollectionAccount;
-use crate::constants::COLLECTION_ACCOUNT_SIZE;
+use crate::account_types::{CollectionAccount, COLLECTION_ACCOUNT_SIZE};
 
 pub fn collection_create_inner(
     ctx: Context<CollectionCreate>,
@@ -34,5 +33,5 @@ pub struct CollectionCreate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct CollectionCreateArgs {
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
 }

--- a/programs/nftoken/src/ix_collection_update.rs
+++ b/programs/nftoken/src/ix_collection_update.rs
@@ -33,6 +33,6 @@ pub struct CollectionUpdate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct CollectionUpdateArgs {
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
     pub creator_can_update: bool,
 }

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -1,5 +1,4 @@
 use crate::account_types::*;
-use crate::constants::*;
 use crate::errors::*;
 use anchor_lang::prelude::*;
 use std::convert::TryInto;
@@ -56,10 +55,10 @@ pub struct MintlistCreate<'info> {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct MintlistCreateArgs {
     /// Information like name, avatar, etc of the mintlist is stored offchain.
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
 
     /// We create a new collection for every Mintlist.
-    pub collection_metadata_url: [u8; 64],
+    pub collection_metadata_url: [u8; 96],
 
     /// Timestamp when minting is allowed.
     pub go_live_date: i64,

--- a/programs/nftoken/src/ix_mintlist_mint_nft.rs
+++ b/programs/nftoken/src/ix_mintlist_mint_nft.rs
@@ -7,7 +7,6 @@ use anchor_lang::solana_program::sysvar::{slot_hashes, SysvarId};
 use arrayref::array_ref;
 
 use crate::account_types::*;
-use crate::constants::*;
 use crate::errors::*;
 
 /// # Mint NFT

--- a/programs/nftoken/src/ix_nft_create.rs
+++ b/programs/nftoken/src/ix_nft_create.rs
@@ -1,5 +1,4 @@
 use crate::account_types::*;
-use crate::constants::*;
 use crate::errors::*;
 use anchor_lang::prelude::*;
 
@@ -70,6 +69,6 @@ pub struct NftCreate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct NftCreateArgs {
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
     pub collection_included: bool,
 }

--- a/programs/nftoken/src/ix_nft_transfer.rs
+++ b/programs/nftoken/src/ix_nft_transfer.rs
@@ -3,11 +3,12 @@ use crate::constants::*;
 use crate::errors::*;
 use anchor_lang::prelude::*;
 
+/// # Transfer NFT
+///
 /// Transfer an NFT to a different owner
 ///
 /// Either the *owner* or the *delegate* can take this action.
 pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
-    // TODO check that you are either the delegate or the owner
     let signer = &ctx.accounts.signer;
     let nft = &mut ctx.accounts.nft;
 
@@ -17,12 +18,12 @@ pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
         // The NFT holder can make a transfer
         nft.holder.key() == signer.key()
             // So can the delegate, if the delegate is set.
-            || delegate.key() == signer.key();
+            || (delegate.key() != NULL_PUBKEY && delegate.key() == signer.key());
 
     let recipient = ctx.accounts.recipient.key();
 
-    require!(recipient != NULL_PUBKEY, NftokenError::TransferUnauthorized);
-    require!(transfer_allowed, NftokenError::TransferUnauthorized);
+    require!(recipient != NULL_PUBKEY, NftokenError::Unauthorized);
+    require!(transfer_allowed, NftokenError::Unauthorized);
 
     nft.holder = recipient;
     nft.delegate = NULL_PUBKEY;

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -30,6 +30,6 @@ pub struct NftUpdate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct NftUpdateArgs {
-    pub metadata_url: [u8; 64],
+    pub metadata_url: [u8; 96],
     pub creator_can_update: bool,
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -31,7 +31,7 @@ pub mod ix_nft_unset_collection;
 pub mod ix_nft_unset_delegate;
 pub mod ix_nft_update;
 
-declare_id!("nf4i4ZyQcYa3KbRnQDzBAncVpLJtS99aMEbjU2PwyKs");
+declare_id!("nft54LYxr6noyvwaQKChAmRpnvn6yZGZkFDtajPz3u8");
 
 #[program]
 pub mod nftoken {


### PR DESCRIPTION
We give 96 characters for the Metadata URL now and we update the NFT and collection account sizes.

When SOL is $100:

```
│ collection │    '200 Bytes'     │ '0.002 SOL'  │  '$0.23'   │   '2,282,880 Lamports'    │
│     nft    │    '240 Bytes'     │ '0.003 SOL'  │  '$0.26'   │   '2,561,280 Lamports'    │
```