### PR TITLE
Update metadata url to variable width string

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -3,7 +3,7 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.localnet]
-nftoken = "nft54LYxr6noyvwaQKChAmRpnvn6yZGZkFDtajPz3u8"
+nftoken = "nf6WUrqMxWm2eQJ9m1H9BPFjKYyBVzue546URy4ULDC"
 
 [scripts]
 test = "pnpm --filter program-tests exec jest"

--- a/program-tests/collection-create.test.ts
+++ b/program-tests/collection-create.test.ts
@@ -1,7 +1,7 @@
 import * as anchor from "@project-serum/anchor";
 import { Keypair, SystemProgram, Transaction } from "@solana/web3.js";
 import { createCollection } from "./utils/create-collection";
-import { DEFAULT_KEYPAIR, program, strToArr } from "./utils/test-utils";
+import { DEFAULT_KEYPAIR, program } from "./utils/test-utils";
 
 describe("ix_collection_create", () => {
   const provider = anchor.AnchorProvider.env();
@@ -12,7 +12,7 @@ describe("ix_collection_create", () => {
   });
 
   test("mints an NFT into a new collection in one transaction", async () => {
-    const metadataUrl = strToArr("hi metadata", 96);
+    const metadataUrl = "hi metadata";
     const collection_keypair = Keypair.generate();
     const nft_keypair = Keypair.generate();
     const creator = DEFAULT_KEYPAIR.publicKey;

--- a/program-tests/collection-update.test.ts
+++ b/program-tests/collection-update.test.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@project-serum/anchor";
 import { createCollection } from "./utils/create-collection";
-import { DEFAULT_KEYPAIR, program, strToArr } from "./utils/test-utils";
+import { DEFAULT_KEYPAIR, program } from "./utils/test-utils";
 
 describe("update collection", () => {
   // Configure the client to use the local cluster.
@@ -12,7 +12,7 @@ describe("update collection", () => {
   test("properly updates metadata", async () => {
     const { collection_pubkey } = await createCollection({});
 
-    const metadata_url = strToArr("new-meta", 96);
+    const metadata_url = "new-meta";
     const creator_can_update = true;
 
     const signature = await program.methods
@@ -39,7 +39,7 @@ describe("update collection", () => {
   test("doesn't allow update if !creator_can_update", async () => {
     const { collection_pubkey } = await createCollection({});
 
-    const metadata_url = strToArr("new-meta", 96);
+    const metadata_url = "new-meta";
     const creator_can_update = false;
 
     const signature = await program.methods

--- a/program-tests/mintlist-mint-nft.test.ts
+++ b/program-tests/mintlist-mint-nft.test.ts
@@ -8,7 +8,7 @@ import {
   createMintlistWithInfos,
   getMintlistData,
 } from "./utils/mintlist";
-import { DEFAULT_KEYPAIR, program } from "./utils/test-utils";
+import { arrayToStr, DEFAULT_KEYPAIR, program } from "./utils/test-utils";
 
 describe("mintlist_mint_nft", () => {
   const provider = anchor.AnchorProvider.env();
@@ -62,12 +62,14 @@ describe("mintlist_mint_nft", () => {
 
     console.log("Mintlist Mint NFT sig:", sig);
 
-    await getMintlistData({
+    const data = await getMintlistData({
       program: program,
       mintlistPubkey: mintlistAddress,
     });
+    const nft = await program.account.nftAccount.fetch(nftKeypair.publicKey);
 
-    // TODO: expect stuff has changed
+    expect(data.mintInfos[0].minted).toEqual(true);
+    expect(nft.metadataUrl).toEqual(arrayToStr(mintInfos[0].metadataUrl));
   });
 
   it("should mint a random NFT", async () => {

--- a/program-tests/nft-create.test.ts
+++ b/program-tests/nft-create.test.ts
@@ -6,12 +6,10 @@ import { createNft } from "./utils/create-nft";
 import { KeypairWallet } from "./utils/KeypairWallet";
 import {
   DEFAULT_KEYPAIR,
-  METADATA_LENGTH,
   NftokenIdl,
   NULL_PUBKEY_STRING,
   program,
   PROGRAM_ID,
-  strToArr,
 } from "./utils/test-utils";
 
 describe("ix_nft_create", () => {
@@ -44,7 +42,7 @@ describe("ix_nft_create", () => {
   test("mints an NFT into a collection", async () => {
     const { creator, collection_keypair } = await createCollection({});
 
-    const nft_metadata_url = strToArr("url2", 96);
+    const nft_metadata_url = "url2";
 
     const nftKeypair = Keypair.generate();
 
@@ -106,7 +104,7 @@ describe("ix_nft_create", () => {
       client: newClient,
     });
 
-    const nft_metadata_url = strToArr("url2", METADATA_LENGTH);
+    const nft_metadata_url = "url2";
 
     const nftKeypair = Keypair.generate();
 

--- a/program-tests/utils/create-collection.ts
+++ b/program-tests/utils/create-collection.ts
@@ -7,7 +7,6 @@ import {
   logCollection,
   NftokenIdlType,
   program,
-  strToArr,
 } from "./test-utils";
 
 export const createCollection = async ({
@@ -26,10 +25,7 @@ export const createCollection = async ({
   collection_pubkey: PublicKey;
   collection_keypair: Keypair;
 }> => {
-  const metadataUrl = strToArr(
-    _metadata_url || generateAlphaNumericString(16),
-    96
-  );
+  const metadataUrl = _metadata_url || generateAlphaNumericString(16);
 
   const collection_keypair = Keypair.generate();
 

--- a/program-tests/utils/create-nft.ts
+++ b/program-tests/utils/create-nft.ts
@@ -6,8 +6,8 @@ import {
   DEFAULT_KEYPAIR,
   generateAlphaNumericString,
   logNft,
-  NftokenIdlType, program,
-  strToArr
+  NftokenIdlType,
+  program,
 } from "./test-utils";
 
 export const createNft = async ({
@@ -25,10 +25,7 @@ export const createNft = async ({
   nft_pubkey: PublicKey;
   nft_keypair: Keypair;
 }> => {
-  const metadata_url = strToArr(
-    _metadata_url || generateAlphaNumericString(16),
-    96
-  );
+  const metadata_url = _metadata_url || generateAlphaNumericString(16);
 
   const nftKeypair = Keypair.generate();
 
@@ -52,9 +49,7 @@ export const createNft = async ({
       throw e;
     });
 
-  const nftResult = await client.account.nftAccount.fetch(
-    nftKeypair.publicKey
-  );
+  const nftResult = await client.account.nftAccount.fetch(nftKeypair.publicKey);
   if (verbose) {
     logNft(nftResult);
   }
@@ -79,7 +74,7 @@ export const updateNft = async ({
   creatorCanUpdate: boolean;
   client?: Program<NftokenTypes>;
 }) => {
-  const metadataUrl = strToArr("new-meta", 96);
+  const metadataUrl = "new-meta";
   await client.methods
     .nftUpdate({ metadataUrl, creatorCanUpdate })
     .accounts({

--- a/program-tests/utils/mintlist.ts
+++ b/program-tests/utils/mintlist.ts
@@ -56,7 +56,7 @@ export async function createEmptyMintlist({
       numNftsTotal,
       mintingOrder,
       metadataUrl: strToArr("random-meta", 96),
-      collectionMetadataUrl: strToArr("coll-random-meta", 96),
+      collectionMetadataUrl: "coll-random-meta"
     })
     .accounts({
       collection: collectionKeypair.publicKey,

--- a/program-tests/utils/test-utils.ts
+++ b/program-tests/utils/test-utils.ts
@@ -14,7 +14,7 @@ export const program = anchor.workspace.Nftoken as Program<_NftokenIdlType>;
 
 export const NftokenIdl = _NftokenIdl;
 export type NftokenIdlType = _NftokenIdlType;
-export const PROGRAM_ID = "nft54LYxr6noyvwaQKChAmRpnvn6yZGZkFDtajPz3u8";
+export const PROGRAM_ID = "nf6WUrqMxWm2eQJ9m1H9BPFjKYyBVzue546URy4ULDC";
 
 // Anchor uses `nodewallet.ts` when testing to find and use a wallet. It automatically signs
 // transactions with this keypair.

--- a/program-tests/utils/test-utils.ts
+++ b/program-tests/utils/test-utils.ts
@@ -56,14 +56,13 @@ export type NftAccount = {
   holder: PublicKey;
   delegate: PublicKey | null;
   creator: PublicKey | null;
-  metadataUrl: Array<number>;
-  createdAt: string;
+  metadataUrl: string | number[];
   collection: PublicKey | null;
 };
 
 export type CollectionAccount = {
   creator: PublicKey | null;
-  metadataUrl: Array<number>;
+  metadataUrl: string | number[];
 };
 
 export type MintInfo = {
@@ -85,9 +84,8 @@ export const logNft = (nft: NftAccount | null) => {
           holder: nft.holder.toString(),
           creator: nft.creator?.toString() ?? null,
           delegate: nft.delegate?.toString() ?? null,
-          metadataUrl: arrayToStr(nft.metadataUrl),
+          metadataUrl: nft.metadataUrl,
           collection: nft.collection?.toString() ?? null,
-          created_at: nft.createdAt,
         },
         null,
         2
@@ -95,16 +93,18 @@ export const logNft = (nft: NftAccount | null) => {
   );
 };
 
-export const logCollection = (coll: CollectionAccount) => {
-  console.log(
-    "Collection:",
-    JSON.stringify(
-      {
-        metadataUrl: arrayToStr(coll.metadataUrl),
-        creator: coll.creator?.toString(),
-      },
-      null,
-      2
-    )
-  );
+export const logCollection = (coll: CollectionAccount | null) => {
+  if (coll) {
+    console.log(
+      "Collection:",
+      JSON.stringify(
+        {
+          metadataUrl: coll.metadataUrl,
+          creator: coll.creator?.toString(),
+        },
+        null,
+        2
+      )
+    );
+  }
 };

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -34,22 +34,20 @@ pub struct NftAccount {
     pub delegate: Pubkey, // 32 = 138
     /// If the NFT has a linked `nft_creators` account which stores royalty information.
     pub has_creators: bool, // 1 = 139
-    /// If the NFT `is_frozen` then it cannot be transferred without permission from the creator
-    /// on the NFT.
-    pub is_frozen: bool, // 1 = 140
-    pub unused_1: u8,             // 1 = 141
-    pub unused_2: u8,             // 1 = 142
-    pub unused_3: u8,             // 1 = 143
-    pub unused_4: u8,             // 1 = 144
+    pub unused_1: u8,             // 1 = 140
+    pub unused_2: u8,             // 1 = 141
+    pub unused_3: u8,             // 1 = 142
+    pub unused_4: u8,             // 1 = 143
     /// Fields beyond this point are variable length and we can't use `getProgramAccounts` with them
     /// anymore.
     pub metadata_url: String, // 4 + bytes for characters
 
                                   // Possible things to add later (consider adding now):
                                   // - transfer counter - u8 - could be useful for marketplace bid accounts
+                                  // - is frozen
 }
 
-pub const NFT_BASE_ACCOUNT_SIZE: usize = 144 + 4;
+pub const NFT_BASE_ACCOUNT_SIZE: usize = 143 + 4;
 pub const NFT_DEFAULT_ACCOUNT_SIZE: usize = NFT_BASE_ACCOUNT_SIZE + 100;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Copy)]

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -6,36 +6,43 @@ use std::convert::TryFrom;
 /// The collection account stores the metadata for a collection of NFTs.
 #[account]
 pub struct CollectionAccount {
+    // Discriminator = 8
     /// This versions the account so that we can store different data formats in the future.
     /// The first version is 1.
-    pub version: u8, // 1
-    pub creator: Pubkey,          // 32 = 33
-    pub creator_can_update: bool, // 1 = 32
-    pub metadata_url: [u8; 96],   // 96 = 128
-                                  // Discriminator 8 = 136
+    pub version: u8, // 1 = 9
+    pub creator: Pubkey,          // 32 = 41
+    pub creator_can_update: bool, // 1 = 42
+    pub metadata_url: String,     // 4 +  bytes
 }
 
-pub const COLLECTION_ACCOUNT_SIZE: usize = 200;
+pub const COLLECTION_BASE_ACCOUNT_SIZE: usize = 42 + 4;
+pub const COLLECTION_DEFAULT_ACCOUNT_SIZE: usize = COLLECTION_BASE_ACCOUNT_SIZE + 100;
 
 #[account]
 pub struct NftAccount {
-    pub version: u8,              // 1
-    pub holder: Pubkey,           // 32 = 33
-    pub creator: Pubkey,          // 32 = 65
-    pub creator_can_update: bool, // 1  = 66
-    pub collection: Pubkey,       // 32 = 98
+    // discriminator = 8
+    pub version: u8,              // 1 = 9
+    pub holder: Pubkey,           // 32 = 41
+    pub creator: Pubkey,          // 32 = 73
+    pub creator_can_update: bool, // 1  = 74
+    pub collection: Pubkey,       // 32 = 106
     /// If this is zero'd out (set to 11111...1111 in base58) then the NFT is not delegated.
-    pub delegate: Pubkey, // 32 = 130
-    pub metadata_url: [u8; 96],   // 96 = 226
-    pub has_creators: bool,       // 1 = 227
-                                  // discriminator 8 = 235
+    pub delegate: Pubkey, // 32 = 138
+    /// If the NFT has a linked `nft_creators` account which stores royalty information.
+    pub has_creators: bool, // 1 = 139
+    /// If the NFT `is_frozen` then it cannot be transferred without permission from the creator
+    /// on the NFT.
+    pub is_frozen: bool, // 1 = 140
+    /// Fields beyond this point are variable length and we can't use `getProgramAccounts` with them
+    /// anymore.
+    pub metadata_url: String, // 4 + bytes for characters
 
-                                  // Possible things to add later:
-                                  // - transfer counter - u8
-                                  // - is frozen - u8 / bool
+                                  // Possible things to add later (consider adding now):
+                                  // - transfer counter - u8 - could be useful for marketplace bid accounts
 }
 
-pub const NFT_ACCOUNT_SIZE: usize = 240;
+pub const NFT_BASE_ACCOUNT_SIZE: usize = 140 + 4;
+pub const NFT_DEFAULT_ACCOUNT_SIZE: usize = NFT_BASE_ACCOUNT_SIZE + 100;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Copy)]
 pub struct NftSecondaryCreator {

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -6,16 +6,20 @@ use std::convert::TryFrom;
 /// The collection account stores the metadata for a collection of NFTs.
 #[account]
 pub struct CollectionAccount {
-    // Discriminator = 8
+    // discriminator = 8
     /// This versions the account so that we can store different data formats in the future.
     /// The first version is 1.
     pub version: u8, // 1 = 9
     pub creator: Pubkey,          // 32 = 41
     pub creator_can_update: bool, // 1 = 42
+    pub unused_1: u8,             // 1 = 43
+    pub unused_2: u8,             // 1 = 44
+    pub unused_3: u8,             // 1 = 45
+    pub unused_4: u8,             // 1 = 46
     pub metadata_url: String,     // 4 +  bytes
 }
 
-pub const COLLECTION_BASE_ACCOUNT_SIZE: usize = 42 + 4;
+pub const COLLECTION_BASE_ACCOUNT_SIZE: usize = 46 + 4;
 pub const COLLECTION_DEFAULT_ACCOUNT_SIZE: usize = COLLECTION_BASE_ACCOUNT_SIZE + 100;
 
 #[account]
@@ -33,6 +37,10 @@ pub struct NftAccount {
     /// If the NFT `is_frozen` then it cannot be transferred without permission from the creator
     /// on the NFT.
     pub is_frozen: bool, // 1 = 140
+    pub unused_1: u8,             // 1 = 141
+    pub unused_2: u8,             // 1 = 142
+    pub unused_3: u8,             // 1 = 143
+    pub unused_4: u8,             // 1 = 144
     /// Fields beyond this point are variable length and we can't use `getProgramAccounts` with them
     /// anymore.
     pub metadata_url: String, // 4 + bytes for characters
@@ -41,7 +49,7 @@ pub struct NftAccount {
                                   // - transfer counter - u8 - could be useful for marketplace bid accounts
 }
 
-pub const NFT_BASE_ACCOUNT_SIZE: usize = 140 + 4;
+pub const NFT_BASE_ACCOUNT_SIZE: usize = 144 + 4;
 pub const NFT_DEFAULT_ACCOUNT_SIZE: usize = NFT_BASE_ACCOUNT_SIZE + 100;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Copy)]

--- a/programs/nftoken/src/ix_collection_create.rs
+++ b/programs/nftoken/src/ix_collection_create.rs
@@ -3,7 +3,7 @@
 //! This creates a *collection* account which NFTs can be associated with.
 use anchor_lang::prelude::*;
 
-use crate::account_types::{CollectionAccount, COLLECTION_ACCOUNT_SIZE};
+use crate::account_types::{CollectionAccount, COLLECTION_BASE_ACCOUNT_SIZE};
 
 pub fn collection_create_inner(
     ctx: Context<CollectionCreate>,
@@ -25,7 +25,7 @@ pub struct CollectionCreate<'info> {
     #[account(mut)]
     pub creator: Signer<'info>,
 
-    #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
+    #[account(init, payer = creator, space = COLLECTION_BASE_ACCOUNT_SIZE + args.metadata_url.len())]
     pub collection: Account<'info, CollectionAccount>,
 
     pub system_program: Program<'info, System>,
@@ -33,5 +33,5 @@ pub struct CollectionCreate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct CollectionCreateArgs {
-    pub metadata_url: [u8; 96],
+    pub metadata_url: String,
 }

--- a/programs/nftoken/src/ix_collection_update.rs
+++ b/programs/nftoken/src/ix_collection_update.rs
@@ -33,6 +33,6 @@ pub struct CollectionUpdate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct CollectionUpdateArgs {
-    pub metadata_url: [u8; 96],
+    pub metadata_url: String,
     pub creator_can_update: bool,
 }

--- a/programs/nftoken/src/ix_mintlist_create.rs
+++ b/programs/nftoken/src/ix_mintlist_create.rs
@@ -41,7 +41,7 @@ pub struct MintlistCreate<'info> {
     )]
     pub mintlist: Account<'info, MintlistAccount>,
 
-    #[account(init, payer = creator, space = COLLECTION_ACCOUNT_SIZE)]
+    #[account(init, payer = creator, space = COLLECTION_DEFAULT_ACCOUNT_SIZE)]
     pub collection: Account<'info, CollectionAccount>,
 
     /// SOL wallet to receive proceedings from SOL payments.
@@ -58,7 +58,7 @@ pub struct MintlistCreateArgs {
     pub metadata_url: [u8; 96],
 
     /// We create a new collection for every Mintlist.
-    pub collection_metadata_url: [u8; 96],
+    pub collection_metadata_url: String,
 
     /// Timestamp when minting is allowed.
     pub go_live_date: i64,

--- a/programs/nftoken/src/ix_mintlist_mint_nft.rs
+++ b/programs/nftoken/src/ix_mintlist_mint_nft.rs
@@ -63,7 +63,10 @@ pub fn mintlist_mint_nft_inner(ctx: Context<MintlistMintNft>) -> Result<()> {
     nft.collection = mintlist.collection;
     nft.creator = mintlist.creator;
     nft.holder = ctx.accounts.signer.key();
-    nft.metadata_url = mint_info.metadata_url;
+
+    // TODO: figure out how to convert the fixed mintlist bytes into a utf-8 string
+    // nft.metadata_url = mint_info.metadata_url;
+
     nft.creator_can_update = true;
 
     mintlist.num_nfts_redeemed = mintlist.num_nfts_redeemed.checked_add(1).unwrap();
@@ -141,7 +144,7 @@ pub struct MintlistMintNft<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
 
-    #[account(init, payer = signer, space = NFT_ACCOUNT_SIZE)]
+    #[account(init, payer = signer, space = NFT_DEFAULT_ACCOUNT_SIZE)]
     pub nft: Account<'info, NftAccount>,
 
     #[account(mut, has_one = treasury_sol)]

--- a/programs/nftoken/src/ix_mintlist_mint_nft.rs
+++ b/programs/nftoken/src/ix_mintlist_mint_nft.rs
@@ -64,8 +64,13 @@ pub fn mintlist_mint_nft_inner(ctx: Context<MintlistMintNft>) -> Result<()> {
     nft.creator = mintlist.creator;
     nft.holder = ctx.accounts.signer.key();
 
-    // TODO: figure out how to convert the fixed mintlist bytes into a utf-8 string
-    // nft.metadata_url = mint_info.metadata_url;
+    let metadata_url_vec: Vec<u8> = mint_info
+        .metadata_url
+        .into_iter()
+        // Strip out the null bytes
+        .filter(|&x| x != 0)
+        .collect();
+    nft.metadata_url = String::from_utf8(metadata_url_vec).unwrap();
 
     nft.creator_can_update = true;
 

--- a/programs/nftoken/src/ix_nft_create.rs
+++ b/programs/nftoken/src/ix_nft_create.rs
@@ -61,7 +61,7 @@ pub struct NftCreate<'info> {
     /// CHECK: this can be any type we want
     pub holder: AccountInfo<'info>,
 
-    #[account(init, payer = creator, space = NFT_ACCOUNT_SIZE)]
+    #[account(init, payer = creator, space = NFT_BASE_ACCOUNT_SIZE + args.metadata_url.len())]
     pub nft: Account<'info, NftAccount>,
 
     pub system_program: Program<'info, System>,
@@ -69,6 +69,6 @@ pub struct NftCreate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct NftCreateArgs {
-    pub metadata_url: [u8; 96],
+    pub metadata_url: String,
     pub collection_included: bool,
 }

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -30,6 +30,6 @@ pub struct NftUpdate<'info> {
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]
 pub struct NftUpdateArgs {
-    pub metadata_url: [u8; 96],
+    pub metadata_url: String,
     pub creator_can_update: bool,
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -33,7 +33,7 @@ pub mod ix_nft_unset_collection;
 pub mod ix_nft_unset_delegate;
 pub mod ix_nft_update;
 
-declare_id!("nft54LYxr6noyvwaQKChAmRpnvn6yZGZkFDtajPz3u8");
+declare_id!("nf6WUrqMxWm2eQJ9m1H9BPFjKYyBVzue546URy4ULDC");
 
 #[program]
 pub mod nftoken {


### PR DESCRIPTION
This allows using even smaller accounts. This is possible now due to the new Solana `realloc` instruction which allows us to resize accounts.

## TODO

- [x] Figure out how to convert the `[u8]` information stored in the mintlist to a string