### PR TITLE
Add ability for the creator to freeze an NFT account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 test-ledger/
 target/
 .anchor
+
+docs/.obsidian

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -11,6 +11,13 @@ NFToken is a new, simple standard for Solana NFTs. NFToken makes it easy for dev
 
 NFToken is designed to be simple, cheap, and flexible.
 
+---
+
+Who is the doc written for?
+
+- People new to the Solana ecosystem
+- Developers
+
 ## Get Started
 
 ## NFTs

--- a/program-tests/utils/create-nft.ts
+++ b/program-tests/utils/create-nft.ts
@@ -65,18 +65,24 @@ export const updateNft = async ({
   nft_pubkey,
   authority,
   metadataUrl: _metadataUrl,
+  isFrozen,
   authorityCanUpdate,
   client = program,
 }: {
   nft_pubkey: PublicKey;
   authority: PublicKey;
+  isFrozen?: boolean;
   metadataUrl: string;
   authorityCanUpdate: boolean;
   client?: Program<NftokenTypes>;
 }) => {
   const metadataUrl = "new-meta";
   await client.methods
-    .nftUpdateV1({ metadataUrl, authorityCanUpdate })
+    .nftUpdateV1({
+      metadataUrl,
+      authorityCanUpdate,
+      isFrozen: isFrozen ?? false,
+    })
     .accounts({
       nft: nft_pubkey,
       authority,

--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -34,10 +34,10 @@ pub struct NftAccount {
     pub delegate: Pubkey, // 32 = 138
     /// If the NFT has a linked `nft_creators` account which stores royalty information.
     pub has_creators: bool, // 1 = 139
-    pub unused_1: u8,               // 1 = 140
-    pub unused_2: u8,               // 1 = 141
-    pub unused_3: u8,               // 1 = 142
-    pub unused_4: u8,               // 1 = 143
+    pub is_frozen: bool,            // 1 = 140
+    pub unused_1: u8,               // 1 = 141
+    pub unused_2: u8,               // 1 = 142
+    pub unused_3: u8,               // 1 = 143
     /// Fields beyond this point are variable length and we can't use `getProgramAccounts` with them
     /// anymore.
     pub metadata_url: String, // 4 + bytes for characters

--- a/programs/nftoken/src/ix_nft_transfer.rs
+++ b/programs/nftoken/src/ix_nft_transfer.rs
@@ -8,9 +8,11 @@ use anchor_lang::prelude::*;
 /// Transfer an NFT to a different owner
 ///
 /// Either the *owner* or the *delegate* can take this action.
-pub fn transfer_nft_inner(ctx: Context<TransferNft>) -> Result<()> {
+pub fn nft_transfer_inner(ctx: Context<TransferNft>) -> Result<()> {
     let signer = &ctx.accounts.signer;
     let nft = &mut ctx.accounts.nft;
+
+    require!(!nft.is_frozen, NftokenError::Unauthorized);
 
     let delegate = nft.delegate;
 

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -12,8 +12,9 @@ pub fn nft_update_inner(ctx: Context<NftUpdate>, args: NftUpdateArgs) -> Result<
     require!(action_allowed, NftokenError::Unauthorized);
     require!(nft.authority_can_update, NftokenError::Unauthorized);
 
-    nft.metadata_url = args.metadata_url;
     nft.authority_can_update = args.authority_can_update;
+    nft.is_frozen = args.is_frozen;
+    nft.metadata_url = args.metadata_url;
 
     Ok(())
 }
@@ -32,4 +33,5 @@ pub struct NftUpdate<'info> {
 pub struct NftUpdateArgs {
     pub metadata_url: String,
     pub authority_can_update: bool,
+    pub is_frozen: bool,
 }

--- a/programs/nftoken/src/lib.rs
+++ b/programs/nftoken/src/lib.rs
@@ -48,7 +48,7 @@ pub mod nftoken {
     }
 
     pub fn nft_transfer_v1(ctx: Context<TransferNft>) -> Result<()> {
-        return transfer_nft_inner(ctx);
+        return nft_transfer_inner(ctx);
     }
 
     pub fn nft_set_delegate_v1(ctx: Context<NftSetDelegate>) -> Result<()> {


### PR DESCRIPTION
Relevant for #34

## Questions / Decisions

- Who can freeze an NFT?
  - The authority of the NFT.
- When can an NFT be frozen / unfrozen?
  - The authority can freeze / unfreeze when the nft has `authority_can_update`
- What does freezing restrict?
  - Any `nft_transfer` call must have `is_frozen=false`