### PR TITLE
Don't allow scrolling when nav is open

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -40,6 +40,7 @@ export default function App({ Component, pageProps }: AppProps) {
         { opacity: 1, transform: ["translateY(-8px)", "translateY(0)"] },
         { delay: stagger(0.05, { start: 0.05 }) }
       );
+      document.body.classList.add("no-scroll");
     } else {
       animate("nav.mobile", {
         pointerEvents: "none",
@@ -48,6 +49,7 @@ export default function App({ Component, pageProps }: AppProps) {
         paddingBottom: 0,
       });
       animate("nav.mobile a", { opacity: 0 });
+      document.body.classList.remove("no-scroll");
     }
   }, [navOpen]);
 


### PR DESCRIPTION
Small tweak: don’t allow scrolling behind the mobile nav when the nav is open. 