### PR TITLE
Fix link on homepage

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -247,18 +247,19 @@ export default function App({ Component, pageProps }: AppProps) {
 function NavContent() {
   const router = useRouter();
 
+  const currentNavItem = nav.find((item) => item.href === router.pathname);
+
   return (
     <>
       <div className="container">
-        <div
-          className="active-highlight"
-          style={{
-            top:
-              nav.indexOf(nav.find((item) => item.href === router.pathname)!) *
-                2.25 +
-              "rem",
-          }}
-        ></div>
+        {currentNavItem && (
+          <div
+            className="active-highlight"
+            style={{
+              top: nav.indexOf(currentNavItem) * 2.25 + "rem",
+            }}
+          ></div>
+        )}
 
         {nav.map((item) => (
           <div className="nav-item" key={item.title}>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Index() {
                   <ChevronRightIcon />
                 </a>
               </Link>
-              <Link href="/getting-started">
+              <Link href="/create-an-nft">
                 <a className="luma-button flex-center icon-right round link large secondary">
                   Create an NFT
                   <ChevronRightIcon />


### PR DESCRIPTION
Changes the link on the homepage from `/getting-started` to `/create-an-nft`. 

Also fixes the highlight on the nav sidebar if we’re on a 404 page. 

| before | after | 
| --- | --- | 
| ![2022-06-16 at 12 05 44@2x](https://user-images.githubusercontent.com/30215449/174116070-b2b34172-46d1-4661-98b9-0f45d6301693.png) | ![2022-06-16 at 12 07 02@2x](https://user-images.githubusercontent.com/30215449/174116022-27125b7d-bee4-409e-a51c-5b4571af4c79.png) |