### PR TITLE
Loading indicator for image uploading

### DIFF
--- a/docs/components/CreateNftSection.tsx
+++ b/docs/components/CreateNftSection.tsx
@@ -197,7 +197,7 @@ const ImageDropZone = () => {
   const { values, setFieldValue } = useFormikContext();
   const data = values as FormData;
 
-  const [uploading, setUploading] = useState(true);
+  const [uploading, setUploading] = useState(false);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: ACCEPT_IMAGE_PROP,

--- a/docs/components/CreateNftSection.tsx
+++ b/docs/components/CreateNftSection.tsx
@@ -236,8 +236,13 @@ const ImageDropZone = () => {
       <style jsx>{`
         .container.with-image {
           display: grid;
-          grid-template-columns: 2fr 1fr;
+          grid-template-columns: 1fr 8rem;
           grid-column-gap: 1rem;
+        }
+
+        /* Make sure height doesn't jump when image is added on the right. */
+        .container :global(.dropzone-wrapper) {
+          height: 8rem;
         }
 
         img {

--- a/docs/components/CreateNftSection.tsx
+++ b/docs/components/CreateNftSection.tsx
@@ -207,10 +207,12 @@ const ImageDropZone = () => {
 
       setUploading(true);
 
-      const { file_url } = await uploadImageToS3({ file });
-      setFieldValue("image", file_url);
-
-      setUploading(false);
+      try {
+        const { file_url } = await uploadImageToS3({ file });
+        setFieldValue("image", file_url);
+      } finally {
+        setUploading(false);
+      }
     },
     noKeyboard: true,
   });

--- a/docs/components/CreateNftSection.tsx
+++ b/docs/components/CreateNftSection.tsx
@@ -197,14 +197,20 @@ const ImageDropZone = () => {
   const { values, setFieldValue } = useFormikContext();
   const data = values as FormData;
 
+  const [uploading, setUploading] = useState(false);
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: ACCEPT_IMAGE_PROP,
     multiple: false,
     onDrop: async (files) => {
       const [file] = files;
-      const { file_url } = await uploadImageToS3({ file });
 
+      setUploading(true);
+
+      const { file_url } = await uploadImageToS3({ file });
       setFieldValue("image", file_url);
+
+      setUploading(false);
     },
     noKeyboard: true,
   });
@@ -214,6 +220,7 @@ const ImageDropZone = () => {
       <DropZone
         label="NFT Image"
         isDragActive={isDragActive}
+        isLoading={uploading}
         rootProps={getRootProps()}
         inputProps={getInputProps()}
       />

--- a/docs/components/LuxDropZone.tsx
+++ b/docs/components/LuxDropZone.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React from "react";
+import { LuxSpinner } from "../components/LuxSpinner";
 import { DropzoneInputProps, DropzoneRootProps } from "react-dropzone";
 import { PhotographIcon } from "@heroicons/react/outline";
 
@@ -33,7 +34,7 @@ export const DropZone = ({
     >
       <div>
         {inputProps && <input {...inputProps} />}
-        {isLoading ? <div className="spinner" /> : icon}
+        {isLoading ? <LuxSpinner /> : icon}
         <div className="label text-lg b animated">{label}</div>
 
         {sublabel && (
@@ -42,30 +43,6 @@ export const DropZone = ({
           </div>
         )}
       </div>
-
-      <style jsx>{`
-        .spinner {
-          height: 1.5rem;
-          width: 1.5rem;
-          margin: 0 auto;
-          /* Margin aligns it with where the icon would be. */
-          margin-bottom: 1.3rem;
-          margin-top: 0.2rem;
-          border-radius: 99px;
-          border: 4px solid var(--primary-border-color);
-          border-top-color: var(--primary-color);
-          animation: spin 0.75s linear infinite;
-        }
-
-        @keyframes spin {
-          from {
-            transform: rotate(0deg);
-          }
-          to {
-            transform: rotate(360deg);
-          }
-        }
-      `}</style>
     </div>
   );
 };

--- a/docs/components/LuxDropZone.tsx
+++ b/docs/components/LuxDropZone.tsx
@@ -33,7 +33,7 @@ export const DropZone = ({
     >
       <div>
         {inputProps && <input {...inputProps} />}
-        {icon}
+        {isLoading ? <div className="spinner" /> : icon}
         <div className="label text-lg b animated">{label}</div>
 
         {sublabel && (
@@ -42,6 +42,30 @@ export const DropZone = ({
           </div>
         )}
       </div>
+
+      <style jsx>{`
+        .spinner {
+          height: 1.5rem;
+          width: 1.5rem;
+          margin: 0 auto;
+          /* Margin aligns it with where the icon would be. */
+          margin-bottom: 1.3rem;
+          margin-top: 0.2rem;
+          border-radius: 99px;
+          border: 4px solid var(--primary-border-color);
+          border-top-color: var(--primary-color);
+          animation: spin 0.75s linear infinite;
+        }
+
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      `}</style>
     </div>
   );
 };

--- a/docs/components/LuxSpinner.tsx
+++ b/docs/components/LuxSpinner.tsx
@@ -1,0 +1,16 @@
+export const LuxSpinner = () => {
+  return (
+    <svg className="lux-spinner" viewBox="0 0 66 66">
+      <circle
+        className="path"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="8"
+        strokeLinecap="round"
+        cx="33"
+        cy="33"
+        r="28"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
The existing loading animation (the drop zone “pulses” a little bit from opacity 0.8 to opacity 1) didn’t feel very obvious. Instead, I’ve added a loading spinner that replaces the icon while the image is uploading. 

https://user-images.githubusercontent.com/30215449/174159545-445dfd12-5575-4eb4-9b88-5184bb0f855a.mp4