### PR TITLE
Footer improvements

### DIFF
--- a/docs/components/all-pages/Footer.tsx
+++ b/docs/components/all-pages/Footer.tsx
@@ -26,9 +26,13 @@ export const Footer = () => {
           width: 100%;
         }
 
+        :global(body) {
+          --footer-max-width: 52rem;
+        }
+
         .footer-inner {
+          max-width: var(--footer-max-width);
           width: 100%;
-          max-width: 52rem;
           margin: 0 auto;
         }
 

--- a/docs/components/all-pages/Footer.tsx
+++ b/docs/components/all-pages/Footer.tsx
@@ -56,7 +56,8 @@ export const Footer = () => {
 
         @media (max-width: ${ResponsiveBreakpoint.medium}) {
           .footer-inner {
-            padding: 1.25rem 1.5rem;
+            padding-top: 1.25rem;
+            padding-bottom: 1.25rem;
           }
         }
       `}</style>

--- a/docs/components/all-pages/Footer.tsx
+++ b/docs/components/all-pages/Footer.tsx
@@ -1,5 +1,5 @@
-import TwitterIcon from "../icons/Twitter.svg";
-import { ResponsiveBreakpoint } from "../utils/style-constants";
+import TwitterIcon from "../../icons/Twitter.svg";
+import { ResponsiveBreakpoint } from "../../utils/style-constants";
 
 export const Footer = () => {
   return (
@@ -23,6 +23,7 @@ export const Footer = () => {
         footer {
           padding: 2rem 1.5rem;
           background-color: var(--tertiary-bg-color);
+          width: 100%;
         }
 
         .footer-inner {

--- a/docs/components/all-pages/Footer.tsx
+++ b/docs/components/all-pages/Footer.tsx
@@ -21,17 +21,13 @@ export const Footer = () => {
 
       <style jsx>{`
         footer {
-          padding: 2rem 1.5rem;
           background-color: var(--tertiary-bg-color);
           width: 100%;
         }
 
-        :global(body) {
-          --footer-max-width: 52rem;
-        }
-
         .footer-inner {
-          max-width: var(--footer-max-width);
+          padding: 2rem 1.5rem;
+          max-width: 60rem;
           width: 100%;
           margin: 0 auto;
         }
@@ -59,7 +55,7 @@ export const Footer = () => {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.medium}) {
-          footer {
+          .footer-inner {
             padding: 1.25rem 1.5rem;
           }
         }

--- a/docs/components/all-pages/Header.tsx
+++ b/docs/components/all-pages/Header.tsx
@@ -123,8 +123,9 @@ export const Header = () => {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.medium}) {
-          header {
-            padding: 1rem 1.5rem;
+          .header-inner {
+            padding-top: 1rem;
+            padding-bottom: 1rem;
           }
 
           button.mobile-nav {

--- a/docs/components/all-pages/Header.tsx
+++ b/docs/components/all-pages/Header.tsx
@@ -67,7 +67,6 @@ export const Header = () => {
 
       <style jsx>{`
         header {
-          padding: 1.2rem 3rem;
           border-top: 4px solid var(--brand-color);
           border-bottom: 1px solid var(--secondary-border-color);
           position: sticky;
@@ -78,8 +77,9 @@ export const Header = () => {
 
         .header-inner {
           width: 100%;
-          max-width: 53rem;
           margin: 0 auto;
+          max-width: 60rem;
+          padding: 1.5rem;
         }
 
         button.mobile-nav {

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -63,7 +63,7 @@ const DocsPage = ({ Component, pageProps }: AppProps) => {
         .content {
           display: grid;
           grid-template-columns: max-content 1fr;
-          grid-column-gap: 2rem;
+          grid-column-gap: 6rem;
           height: 100%;
 
           width: 100%;
@@ -76,7 +76,7 @@ const DocsPage = ({ Component, pageProps }: AppProps) => {
         }
 
         nav.desktop .nav-inner {
-          padding-left: 3rem;
+          padding-left: 0.75rem;
           position: sticky;
           top: 8rem;
         }
@@ -95,7 +95,9 @@ const DocsPage = ({ Component, pageProps }: AppProps) => {
         }
 
         main {
-          padding: 3rem 4rem 5rem 4rem;
+          padding-top: 3rem;
+          padding-bottom: 5rem;
+          padding-right: 1.5rem;
         }
 
         @media (max-width: ${ResponsiveBreakpoint.medium}) {

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 import { Header } from "../components/all-pages/Header";
 import { NextPreviousButtons } from "../components/all-pages/NextPreviousButtons";
 import { TabBar } from "../components/all-pages/TabBar";
-import { Footer } from "../components/Footer";
+import { Footer } from "../components/all-pages/Footer";
 import { SocialHead } from "../components/SocialHead";
 import "../public/globals.css";
 import "../styles/app.scss";

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -101,10 +101,6 @@ const DocsPage = ({ Component, pageProps }: AppProps) => {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.medium}) {
-          .wrapper {
-            display: block;
-          }
-
           .content {
             display: block;
           }

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -137,7 +137,10 @@ export default function Index() {
           }
 
           .inner {
-            padding-bottom: 6rem;
+            padding-bottom: 5rem;
+
+            /* No more visual centering necessary. */
+            margin-bottom: 0;
 
             grid-template-columns: 1fr;
             grid-template-rows: max-content max-content;

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -44,11 +44,12 @@ export default function Index() {
           min-height: 100vh;
           display: grid;
           grid-template-rows: 1fr max-content;
+
+          --footer-max-width: 62rem;
         }
 
         .inner {
           padding: 1.5rem;
-          max-width: 1200px;
           margin: 0 auto;
 
           display: grid;
@@ -93,6 +94,10 @@ export default function Index() {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.large}) {
+          .wrapper {
+            --footer-max-width: 47rem;
+          }
+
           .graphic {
             max-width: 300px;
             margin: 0 auto;
@@ -111,7 +116,7 @@ export default function Index() {
           }
 
           h1 {
-            font-size: 2.5rem;
+            font-size: 3rem;
             font-weight: 600;
           }
 
@@ -135,6 +140,10 @@ export default function Index() {
         @media (max-width: ${ResponsiveBreakpoint.small}) {
           .wrapper {
             place-items: start center;
+          }
+
+          h1 {
+            font-size: 2.5rem;
           }
 
           .inner {

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -2,6 +2,7 @@ import { ChevronRightIcon } from "@heroicons/react/outline";
 import Link from "next/link";
 import { SocialHead } from "../components/SocialHead";
 import { ResponsiveBreakpoint } from "../utils/style-constants";
+import { Footer } from "../components/all-pages/Footer";
 
 export default function Index() {
   return (
@@ -33,19 +34,22 @@ export default function Index() {
           </div>
           <img src="/sketch.png" alt="" className="graphic" />
         </div>
+
+        <Footer />
       </div>
 
       <style jsx>{`
         .wrapper {
           border-top: 4px solid var(--brand-color);
+          min-height: 100vh;
           display: grid;
-          place-items: center;
-          height: 85vh; /* For visual centering. */
+          grid-template-rows: 1fr max-content;
         }
 
         .inner {
           padding: 1.5rem;
           max-width: 1200px;
+          margin: 0 auto;
 
           display: grid;
           grid-template-columns: 1fr 300px;
@@ -54,7 +58,7 @@ export default function Index() {
         }
 
         .content {
-          margin-top: 2rem;
+          margin-top: 1rem;
         }
 
         .graphic {

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -44,17 +44,19 @@ export default function Index() {
           min-height: 100vh;
           display: grid;
           grid-template-rows: 1fr max-content;
-
-          --footer-max-width: 62rem;
         }
 
         .inner {
           padding: 1.5rem;
           margin: 0 auto;
+          max-width: 60rem;
+
+          /* To visually center. */
+          margin-bottom: 4rem;
 
           display: grid;
-          grid-template-columns: 1fr 300px;
-          grid-column-gap: 120px;
+          grid-template-columns: 2fr 1fr;
+          grid-column-gap: 6rem;
           align-items: center;
         }
 
@@ -80,7 +82,7 @@ export default function Index() {
         }
 
         h1 {
-          font-size: 4rem;
+          font-size: 3.5rem;
           font-weight: 500;
           letter-spacing: -0.02em;
         }
@@ -94,25 +96,17 @@ export default function Index() {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.large}) {
-          .wrapper {
-            --footer-max-width: 47rem;
-          }
-
           .graphic {
             max-width: 300px;
             margin: 0 auto;
           }
 
           .inner {
-            grid-template-columns: 1fr 200px;
-          }
-
-          .content {
-            margin-top: 1rem;
+            grid-column-gap: 4rem;
           }
 
           .logo {
-            height: 1rem;
+            height: 1.5rem;
           }
 
           h1 {
@@ -138,10 +132,6 @@ export default function Index() {
         }
 
         @media (max-width: ${ResponsiveBreakpoint.small}) {
-          .wrapper {
-            place-items: start center;
-          }
-
           h1 {
             font-size: 2.5rem;
           }
@@ -151,7 +141,7 @@ export default function Index() {
 
             grid-template-columns: 1fr;
             grid-template-rows: max-content max-content;
-            grid-row-gap: 75px;
+            grid-row-gap: 5rem;
           }
         }
       `}</style>

--- a/docs/public/globals.css
+++ b/docs/public/globals.css
@@ -51,6 +51,7 @@ article code:not(pre code) {
   color: var(--red-50);
   padding: 0.2em 0.4em;
   border-radius: var(--border-radius);
+  overflow-wrap: anywhere;
 }
 
 body.dark article code:not(pre code) {


### PR DESCRIPTION
- Adds footer to splash page
- Standardizes website’s width across docs and splash page, and did a cleanup of CSS that isn’t necessary anymore. 
- Fixes a bug where [the footer isn’t attached to bottom of the screen](https://user-images.githubusercontent.com/30215449/174666478-8da7abf8-114b-48b2-9e81-7c0177fb6927.png) on short pages on mobile. 

| desktop | mobile | 
| --- | --- | 
| ![2022-06-20 at 15 19 59@2x](https://user-images.githubusercontent.com/30215449/174666132-370a8619-478a-4682-8d2f-849ba302d335.png) | ![localhost_4567_(iPhone 12 Pro)](https://user-images.githubusercontent.com/30215449/174666137-d8978b1c-7e58-40f8-ad7b-ae88a6eb256a.png) |
 