### PR TITLE
Tweak spacing on attribute table heading

### DIFF
--- a/docs/components/AttributeTable.tsx
+++ b/docs/components/AttributeTable.tsx
@@ -19,7 +19,7 @@ export const AttributeTable = ({
           font-weight: var(--medium-font-weight);
           border-bottom: 1px solid var(--secondary-border-color);
           padding-bottom: 0.75rem;
-          margin-bottom: 0.75rem;
+          margin-bottom: 1rem;
           margin-top: 0;
         }
 


### PR DESCRIPTION
I realized after merging the attribute table PR that the spacing above the first cell isn’t the same as all the other cells’ spacing, and it was bothering me so I wanted to land a tiny PR that fixes it.

Before:
![2022-06-23 at 09 15 33@2x](https://user-images.githubusercontent.com/30215449/175307711-2b6bddc5-f588-4d7d-9248-84e35861c1d3.png)

After:
![2022-06-23 at 09 15 17@2x](https://user-images.githubusercontent.com/30215449/175307799-2da778b7-0f35-4a66-ac6f-c8d70c6fae11.png)
