### PR TITLE
Split NFT info by on/off chain metadata

### DIFF
--- a/docs/components/ValueList.tsx
+++ b/docs/components/ValueList.tsx
@@ -11,16 +11,19 @@ import { ResponsiveBreakpoint } from "../utils/style-constants";
 export const ValueList = ({
   attributes,
 }: {
-  attributes: { [key: string]: any };
+  attributes: {
+    label: string;
+    value: string | number | boolean | null | undefined;
+  }[];
 }) => {
   return (
     <>
       <div className="container">
-        {Object.keys(attributes).map((key) => (
-          <React.Fragment key={key}>
+        {attributes.map(({ label, value }) => (
+          <React.Fragment key={label}>
             <div className="value-container">
-              <div className="key">{key}</div>
-              <Value value={attributes[key]} attributeKey={key} />
+              <div className="label">{label}</div>
+              <Value value={value} label={label} />
             </div>
           </React.Fragment>
         ))}
@@ -41,7 +44,7 @@ export const ValueList = ({
           align-items: baseline;
         }
 
-        .value-container .key {
+        .value-container .label {
           font-weight: var(--normal-font-weight);
           color: var(--secondary-color);
           width: 8.5rem;
@@ -56,7 +59,7 @@ export const ValueList = ({
         }
 
         @media (max-width: ${ResponsiveBreakpoint.small}) {
-          .value-container .key {
+          .value-container .label {
             margin-right: 1rem;
           }
         }
@@ -65,13 +68,7 @@ export const ValueList = ({
   );
 };
 
-const Value = ({
-  attributeKey,
-  value,
-}: {
-  attributeKey: string;
-  value: any;
-}) => {
+const Value = ({ label, value }: { label: string; value: any }) => {
   if (typeof value !== "string") {
     return <div>{JSON.stringify(value)}</div>;
   }
@@ -81,7 +78,7 @@ const Value = ({
       <>
         <div className="solana-address flex-center flex-wrap">
           <SolanaAddress address={value} />
-          {attributeKey === "collection" && (
+          {label === "collection" && (
             <LuxButton
               label="View Collection"
               icon={<ArrowRightIcon />}

--- a/docs/pages/collection/[collectionAddress].tsx
+++ b/docs/pages/collection/[collectionAddress].tsx
@@ -112,13 +112,6 @@ export default function CollectionPage({
     attributes[key] = collection[key];
   }
 
-  const traits: { [key: string]: any } = {};
-  if (collection.traits) {
-    for (const entry of collection.traits) {
-      traits[entry.trait_type] = entry.value;
-    }
-  }
-
   return (
     <PageLayout>
       <SocialHead subtitle={collection.name} />
@@ -130,22 +123,30 @@ export default function CollectionPage({
         <div>
           <h2 className="text-secondary">On-Chain Metadata</h2>
           <ValueList
-            attributes={{
-              address: collection.address,
-              authority: collection.authority,
-              authority_can_update: collection.authority_can_update,
-              metadata_url: collection.metadata_url,
-            }}
+            attributes={[
+              { label: "address", value: collection.address },
+              { label: "authority", value: collection.authority },
+              {
+                label: "authority_can_update",
+                value: collection.authority_can_update,
+              },
+              { label: "metadata_url", value: collection.metadata_url },
+            ]}
           />
         </div>
         <div className="traits-column">
           <h2 className="text-secondary">Off-Chain Metadata</h2>
           <ValueList
-            attributes={{
-              image: collection.image,
-              description: collection.description,
-              ...traits,
-            }}
+            attributes={[
+              { label: "image", value: collection.image },
+              { label: "description", value: collection.description },
+              ...(collection.traits
+                ? collection.traits.map((trait) => ({
+                    label: trait.trait_type,
+                    value: trait.value,
+                  }))
+                : []),
+            ]}
           />
         </div>
       </div>

--- a/docs/pages/collection/[collectionAddress].tsx
+++ b/docs/pages/collection/[collectionAddress].tsx
@@ -134,8 +134,7 @@ export default function CollectionPage({
               address: collection.address,
               authority: collection.authority,
               authority_can_update: collection.authority_can_update,
-              description: collection.description,
-              minted_at: collection.minted_at,
+              metadata_url: collection.metadata_url,
             }}
           />
         </div>
@@ -144,7 +143,7 @@ export default function CollectionPage({
           <ValueList
             attributes={{
               image: collection.image,
-              metadata_url: collection.metadata_url,
+              description: collection.description,
               ...traits,
             }}
           />

--- a/docs/pages/nft/[nftAddress].tsx
+++ b/docs/pages/nft/[nftAddress].tsx
@@ -32,20 +32,6 @@ const useNft = ({
   return { data: data!, error, mutate };
 };
 
-const KEYS: (keyof NftokenTypes.NftInfo)[] = [
-  "address",
-  "collection",
-  "holder",
-  "delegate",
-  "authority",
-  "authority_can_update",
-  "name",
-  "description",
-  "image",
-  "minted_at",
-  "metadata_url",
-];
-
 export default function NftPage({
   initialNft,
 }: {

--- a/docs/pages/nft/[nftAddress].tsx
+++ b/docs/pages/nft/[nftAddress].tsx
@@ -94,8 +94,7 @@ export default function NftPage({
                   delegate: nft.delegate,
                   authority: nft.authority,
                   authority_can_update: nft.authority_can_update,
-                  description: nft.description,
-                  minted_at: nft.minted_at,
+                  metadata_url: nft.metadata_url,
                 }}
               />
             </div>
@@ -105,7 +104,7 @@ export default function NftPage({
               <ValueList
                 attributes={{
                   image: nft.image,
-                  metadata_url: nft.metadata_url,
+                  description: nft.description,
                   ...traits,
                 }}
               />

--- a/docs/pages/nft/[nftAddress].tsx
+++ b/docs/pages/nft/[nftAddress].tsx
@@ -63,13 +63,6 @@ export default function NftPage({
     );
   }
 
-  const traits: { [key: string]: any } = {};
-  if (nft.traits) {
-    for (const entry of nft.traits) {
-      traits[entry.trait_type] = entry.value;
-    }
-  }
-
   return (
     <PageLayout>
       <SocialHead subtitle={nft.name} />
@@ -87,26 +80,34 @@ export default function NftPage({
             <div>
               <h2 className="text-secondary">On-Chain Metadata</h2>
               <ValueList
-                attributes={{
-                  address: nft.address,
-                  collection: nft.collection,
-                  holder: nft.holder,
-                  delegate: nft.delegate,
-                  authority: nft.authority,
-                  authority_can_update: nft.authority_can_update,
-                  metadata_url: nft.metadata_url,
-                }}
+                attributes={[
+                  { label: "address", value: nft.address },
+                  { label: "collection", value: nft.collection },
+                  { label: "holder", value: nft.holder },
+                  { label: "delegate", value: nft.delegate },
+                  { label: "authority", value: nft.authority },
+                  {
+                    label: "authority_can_update",
+                    value: nft.authority_can_update,
+                  },
+                  { label: "metadata_url", value: nft.metadata_url },
+                ]}
               />
             </div>
 
             <div className="mt-4">
               <h2 className="text-secondary">Off-Chain Metadata</h2>
               <ValueList
-                attributes={{
-                  image: nft.image,
-                  description: nft.description,
-                  ...traits,
-                }}
+                attributes={[
+                  { label: "image", value: nft.image },
+                  { label: "description", value: nft.description },
+                  ...(nft.traits
+                    ? nft.traits.map((trait) => ({
+                        label: trait.trait_type,
+                        value: trait.value,
+                      }))
+                    : []),
+                ]}
               />
             </div>
           </div>

--- a/docs/pages/nft/[nftAddress].tsx
+++ b/docs/pages/nft/[nftAddress].tsx
@@ -80,11 +80,6 @@ export default function NftPage({
     );
   }
 
-  const attributes: { [key: string]: any } = {};
-  for (const key of KEYS) {
-    attributes[key] = nft[key];
-  }
-
   const traits: { [key: string]: any } = {};
   if (nft.traits) {
     for (const entry of nft.traits) {
@@ -106,15 +101,31 @@ export default function NftPage({
           <div>
             <h1>{nft.name}</h1>
 
-            <ValueList attributes={attributes} />
+            <div>
+              <h2 className="text-secondary">On-Chain Metadata</h2>
+              <ValueList
+                attributes={{
+                  address: nft.address,
+                  collection: nft.collection,
+                  holder: nft.holder,
+                  delegate: nft.delegate,
+                  authority: nft.authority,
+                  authority_can_update: nft.authority_can_update,
+                  description: nft.description,
+                  minted_at: nft.minted_at,
+                }}
+              />
+            </div>
 
             <div className="mt-4">
-              <h2>Traits</h2>
-              {nft.traits && nft.traits.length > 0 ? (
-                <ValueList attributes={traits} />
-              ) : (
-                <div className="traits-empty-state">No traits set.</div>
-              )}
+              <h2 className="text-secondary">Off-Chain Metadata</h2>
+              <ValueList
+                attributes={{
+                  image: nft.image,
+                  metadata_url: nft.metadata_url,
+                  ...traits,
+                }}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Like we did in #162, this splits the metadata on the NFT detail page into on-chain and off-chain metadata, to clear up confusion that developers may have about where metadata is stored. 

![2022-07-01 at 13 40 51@2x](https://user-images.githubusercontent.com/30215449/176944514-88b96fea-fafe-4948-a05a-2cb232934f2a.png)

Live demo: 

- https://nftoken-git-l-5246-split-nft-detail-page-by-onoff-chain.luma-dev.com/nft/uERDSnn8x7Hjv6zPMFpGXrbXEvGVwwBAaViFrDdjXr6
- https://nftoken-git-l-5246-split-nft-detail-page-by-onoff-chain.luma-dev.com/nft/GtmTbLRKJxPAo4ZREr8sWq928sbG9xJo845U5eQNmL2f