### PR TITLE
reallocate new space when updating `metadata_url`

### DIFF
--- a/programs/nftoken/src/account_types.rs
+++ b/programs/nftoken/src/account_types.rs
@@ -1,3 +1,4 @@
+use self::borsh;
 use crate::errors::NftokenError;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::clock::UnixTimestamp;

--- a/programs/nftoken/src/ix_collection_update.rs
+++ b/programs/nftoken/src/ix_collection_update.rs
@@ -1,4 +1,4 @@
-use crate::account_types::CollectionAccount;
+use crate::account_types::{CollectionAccount, COLLECTION_BASE_ACCOUNT_SIZE};
 use crate::errors::NftokenError;
 use anchor_lang::prelude::*;
 
@@ -24,11 +24,12 @@ pub fn collection_update_inner(
 #[derive(Accounts)]
 #[instruction(args: CollectionUpdateArgs)]
 pub struct CollectionUpdate<'info> {
-    #[account(mut, has_one = authority)]
+    #[account(mut, has_one = authority, realloc = COLLECTION_BASE_ACCOUNT_SIZE + args.metadata_url.len(), realloc::payer = authority, realloc::zero = false)]
     pub collection: Account<'info, CollectionAccount>,
 
     #[account(mut)]
     pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]

--- a/programs/nftoken/src/ix_nft_update.rs
+++ b/programs/nftoken/src/ix_nft_update.rs
@@ -1,4 +1,4 @@
-use crate::account_types::NftAccount;
+use crate::account_types::{NftAccount, NFT_BASE_ACCOUNT_SIZE};
 use crate::errors::NftokenError;
 use anchor_lang::prelude::*;
 
@@ -22,11 +22,12 @@ pub fn nft_update_inner(ctx: Context<NftUpdate>, args: NftUpdateArgs) -> Result<
 #[derive(Accounts)]
 #[instruction(args: NftUpdateArgs)]
 pub struct NftUpdate<'info> {
-    #[account(mut, has_one = authority)]
+    #[account(mut, has_one = authority, realloc = NFT_BASE_ACCOUNT_SIZE + args.metadata_url.len(), realloc::payer = authority, realloc::zero = false)]
     pub nft: Account<'info, NftAccount>,
 
     #[account(mut)]
     pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq)]


### PR DESCRIPTION
while updating nfts or collection `metadata_url`, if the length of new `metadata_url` is smaller then it works as allocated space is greater, but when new `metadata_url` is longer than old one, it fails due to lack of space in nft account. this pull request reallocates new space if `metadata_url` changes (new rent paid/claimed by authority if increase/decrease in length of `metadata_url`)